### PR TITLE
setbond, setDelegation does not update PRepManager and PRepStatus

### DIFF
--- a/icon/chainscore.go
+++ b/icon/chainscore.go
@@ -172,6 +172,13 @@ var chainMethods = []*chainMethod{
 		},
 		nil,
 	}, 0, 0}, // TODO change minVer to Revision5
+	{scoreapi.Method{scoreapi.Function, "getPRepManager",
+		scoreapi.FlagReadOnly | scoreapi.FlagExternal, 0,
+		nil,
+		[]scoreapi.DataType{
+			scoreapi.Dict,
+		},
+	}, 0, 0},
 	{scoreapi.Method{scoreapi.Function, "getPReps",
 		scoreapi.FlagReadOnly | scoreapi.FlagExternal, 0,
 		nil,

--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -208,10 +208,14 @@ func (s *chainScore) Ex_getPReps() (map[string]interface{}, error) {
 	blockHeight := s.cc.BlockHeight()
 	jso := es.GetPRepsInJSON(blockHeight)
 	ts := icstate.GetTotalStake(es.State)
-	tsh := new(common.HexInt)
-	tsh.Set(ts)
-	jso["totalStake"] = tsh
+	jso["totalStake"] = intconv.FormatBigInt(ts)
 	jso["blockHeight"] = blockHeight
+	return jso, nil
+}
+
+func (s *chainScore) Ex_getPRepManager() (map[string]interface{}, error) {
+	es := s.cc.GetExtensionState().(*iiss.ExtensionStateImpl)
+	jso := es.GetPRepManagerInJSON()
 	return jso, nil
 }
 

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -392,8 +392,6 @@ func (s *ExtensionStateImpl) SetBond(cc contract.CallContext, from module.Addres
 		if !prep.BonderList().Contains(from) {
 			return errors.Errorf("%s is not in bonder List of %s", from.String(), bond.Address.String())
 		}
-
-		prep.SetBonded(bond.Amount())
 	}
 	if account.Stake().Cmp(new(big.Int).Add(bondAmount, account.Delegating())) == -1 {
 		return errors.Errorf("Not enough voting power")
@@ -407,6 +405,12 @@ func (s *ExtensionStateImpl) SetBond(cc contract.CallContext, from module.Addres
 	if account.Stake().Cmp(new(big.Int).Add(votingAmount, unbondingAmount)) == -1 {
 		return errors.Errorf("Not enough voting power")
 	}
+
+	err = s.pm.ChangeBond(account.Bonds(), bonds)
+	if err != nil {
+		return err
+	}
+
 	account.SetBonds(bonds)
 	tl := account.UpdateUnbonds(ubToAdd, ubToMod)
 	for _, t := range tl {

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -270,6 +270,10 @@ func newCalculation() *calculation {
 	return &calculation{0, 0, nil}
 }
 
+func (s *ExtensionStateImpl) GetPRepManagerInJSON() map[string]interface{} {
+	return s.pm.GetPRepManagerInJSON()
+}
+
 func (s *ExtensionStateImpl) GetPRepsInJSON(blockHeight int64) map[string]interface{} {
 	return s.pm.GetPRepsInJSON(blockHeight)
 }
@@ -302,11 +306,11 @@ func (s *ExtensionStateImpl) SetDelegation(cc contract.CallContext, from module.
 	if account.Stake().Cmp(new(big.Int).Add(ds.GetDelegationAmount(), account.Bond())) == -1 {
 		return errors.Errorf("Not enough voting power")
 	}
-	account.SetDelegation(ds)
 	err = s.pm.ChangeDelegation(account.Delegations(), ds)
 	if err != nil {
 		return err
 	}
+	account.SetDelegation(ds)
 
 	bonds := account.Bonds()
 	event := make([]*icstate.Delegation, 0, len(ds)+len(bonds))

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -271,7 +271,7 @@ func newCalculation() *calculation {
 }
 
 func (s *ExtensionStateImpl) GetPRepManagerInJSON() map[string]interface{} {
-	return s.pm.GetPRepManagerInJSON()
+	return s.pm.ToJSON()
 }
 
 func (s *ExtensionStateImpl) GetPRepsInJSON(blockHeight int64) map[string]interface{} {

--- a/icon/iiss/icstate/state.go
+++ b/icon/iiss/icstate/state.go
@@ -157,7 +157,7 @@ func NewStateFromSnapshot(ss *Snapshot, readonly bool) *State {
 }
 
 func (s *State) RemovePRepStatus(owner module.Address) error {
-	return s.prepBaseCache.Remove(owner)
+	return s.prepStatusCache.Remove(owner)
 }
 
 func (s *State) AddNodeToOwner(node, owner module.Address) error {

--- a/icon/iiss/prepmanager.go
+++ b/icon/iiss/prepmanager.go
@@ -196,7 +196,7 @@ func (pm *PRepManager) GetValidators() []module.Validator {
 	return validators
 }
 
-func (pm *PRepManager) GetPRepManagerInJSON() map[string]interface{} {
+func (pm *PRepManager) ToJSON() map[string]interface{} {
 	ret := make(map[string]interface{})
 	ret["totalStake"] = intconv.FormatBigInt(pm.totalStake)
 	ret["totalDelegated"] = intconv.FormatBigInt(pm.totalDelegated)


### PR DESCRIPTION
Fix PRepStatus.bonded management bug
- add PRepManager.ChangeBond()

Fix PRepStatus.delegated and PRepManager.totalDelegated management bug

- call PRepManager.ChangeDelegation before Account.SetDelegation()
- add getPrepManager JSON-RPC API to check PRepManager.totalDeleagted value