### PR TITLE
BondedRequirement changed

### DIFF
--- a/icon/iiss/icstate/networkvalue.go
+++ b/icon/iiss/icstate/networkvalue.go
@@ -136,7 +136,7 @@ func (s *State) GetBondRequirement() int64 {
 
 func (s *State) SetBondRequirement(value int64) error {
 	if value < 0 || value > 100 {
-		return errors.IllegalArgumentError.New("Bond Requirement should range from 1 to 100")
+		return errors.IllegalArgumentError.New("Bond Requirement should range from 0 to 100")
 	}
 	return setValue(s.store, VarBondRequirement, value)
 }

--- a/icon/iiss/icstate/networkvalue.go
+++ b/icon/iiss/icstate/networkvalue.go
@@ -135,7 +135,7 @@ func (s *State) GetBondRequirement() int64 {
 }
 
 func (s *State) SetBondRequirement(value int64) error {
-	if value < 1 || value > 100 {
+	if value < 0 || value > 100 {
 		return errors.IllegalArgumentError.New("Bond Requirement should range from 1 to 100")
 	}
 	return setValue(s.store, VarBondRequirement, value)

--- a/icon/iiss/icstate/networkvalue_test.go
+++ b/icon/iiss/icstate/networkvalue_test.go
@@ -149,8 +149,9 @@ func setBondRequirementTest(t *testing.T, s *State) {
 	actual = s.GetBondRequirement()
 	assert.Equal(t, br, actual)
 
-	err := s.SetBondRequirement(0)
-	assert.Error(t, err)
+	br = 0
+	err := s.SetBondRequirement(br)
+	assert.NoError(t, err)
 	actual = s.GetBondRequirement()
 	assert.Equal(t, br, actual)
 }

--- a/icon/iiss/icstate/prepstatus.go
+++ b/icon/iiss/icstate/prepstatus.go
@@ -132,11 +132,17 @@ func (ps *PRepStatus) SetDelegated(delegated *big.Int) {
 // if bondedDelegation > totalVoted
 //    bondedDelegation = totalVoted
 func (ps *PRepStatus) GetBondedDelegation(bondRequirement int64) *big.Int {
-	if bondRequirement < 1 || bondRequirement > 100 {
-		// should not be 0 for bond requirement
+	if bondRequirement < 0 || bondRequirement > 100 {
+		// should not be negative or over 100 for bond requirement
 		return big.NewInt(0)
 	}
 	totalVoted := ps.GetVoted() // bonded + delegated
+	if bondRequirement == 0 {
+		// when bondRequirement is 0, it means no threshold for BondedRequirement,
+		// so it returns 100% of totalVoted.
+		// And it should not be divided by 0 in the following code that could occurs Panic.
+		return totalVoted
+	}
 	multiplier := big.NewInt(100)
 	bondedDelegation := new(big.Int).Mul(ps.bonded, multiplier) // not divided by bond requirement yet
 

--- a/icon/iiss/icstate/prepstatus_test.go
+++ b/icon/iiss/icstate/prepstatus_test.go
@@ -116,7 +116,7 @@ func TestPRepStatus_GetBondedDelegation(t *testing.T) {
 	bonded = big.NewInt(int64(999))
 	s.GetPRepStatus(addr1, true).SetBonded(bonded)
 	res = status1.GetBondedDelegation(0)
-	assert.Equal(t, 0, res.Cmp(big.NewInt(int64(0))))
+	assert.Equal(t, 0, res.Cmp(big.NewInt(int64(100998))))
 
 	// 101 for bond requirement
 	delegated = big.NewInt(int64(99999))

--- a/icon/iiss/icstate/prepstatus_test.go
+++ b/icon/iiss/icstate/prepstatus_test.go
@@ -116,7 +116,7 @@ func TestPRepStatus_GetBondedDelegation(t *testing.T) {
 	bonded = big.NewInt(int64(999))
 	s.GetPRepStatus(addr1, true).SetBonded(bonded)
 	res = status1.GetBondedDelegation(0)
-	assert.Equal(t, 0, res.Cmp(big.NewInt(int64(100998))))
+	assert.Equal(t, 0, res.Cmp(big.NewInt(status1.GetVoted().Int64())))
 
 	// 101 for bond requirement
 	delegated = big.NewInt(int64(99999))

--- a/icon/iiss/icstate/prepstatus_test.go
+++ b/icon/iiss/icstate/prepstatus_test.go
@@ -116,7 +116,7 @@ func TestPRepStatus_GetBondedDelegation(t *testing.T) {
 	bonded = big.NewInt(int64(999))
 	s.GetPRepStatus(addr1, true).SetBonded(bonded)
 	res = status1.GetBondedDelegation(0)
-	assert.Equal(t, 0, res.Cmp(big.NewInt(status1.GetVoted().Int64())))
+	assert.Equal(t, 0, res.Cmp(status1.GetVoted()))
 
 	// 101 for bond requirement
 	delegated = big.NewInt(int64(99999))


### PR DESCRIPTION
When bondRequirement is 0, it means no threshold for BondedRequirement,
So it returns 100% of totalVoted.
And it should not be divided by 0 in the following code that could occurs Panic.