### PR TITLE
IC2-80: fix setBond bug

### DIFF
--- a/icon/iiss/icstate/account.go
+++ b/icon/iiss/icstate/account.go
@@ -268,28 +268,39 @@ func (a *Account) GetUnbondingInfo(bonds Bonds, unbondingHeight int64) (Unbonds,
 	uDiff := new(big.Int)
 	var ubToAdd, ubToMod []*Unbond
 	for _, nb := range bonds {
+		bondExist := false
 		for _, ob := range a.bonds {
 			diff := new(big.Int)
 			if nb.To().Equal(ob.To()) {
+				bondExist = true
 				diff.Sub(ob.Amount(), nb.Amount())
 				if diff.Sign() == 1 {
 					unbond := Unbond{nb.Address, diff, unbondingHeight}
 					ubToAdd = append(ubToAdd, &unbond)
 					uDiff.Add(uDiff, diff)
-				} else {
-					for _, ub := range a.unbonds {
-						if nb.To().Equal(ub.Address) {
-							value := new(big.Int).Add(ub.Value, diff)
-							if value.Sign() == -1 {
-								uDiff.Add(uDiff, value.Abs(value))
-								value = new(big.Int)
-							}
-							unbond := Unbond{nb.Address, value, unbondingHeight}
-							ubToMod = append(ubToMod, &unbond)
-							uDiff.Add(uDiff, diff)
+				}
+				for _, ub := range a.unbonds {
+					if nb.To().Equal(ub.Address) {
+						value := new(big.Int).Add(ub.Value, diff)
+						if value.Sign() == -1 {
+							uDiff.Add(uDiff, value.Abs(value))
+							value = new(big.Int)
+						}
+						unbond := Unbond{nb.Address, value, unbondingHeight}
+						ubToMod = append(ubToMod, &unbond)
+						uDiff.Add(uDiff, diff)
+						if len(ubToAdd) > 0 && nb.Address.Equal(ubToAdd[len(ubToAdd)-1].Address) {
+							ubToAdd = ubToAdd[:len(ubToAdd)-1]
 						}
 					}
 				}
+			}
+		}
+		for _, ub := range a.unbonds {
+			if nb.To().Equal(ub.Address) && !bondExist {
+				unbond := Unbond{nb.Address, new(big.Int), unbondingHeight}
+				ubToMod = append(ubToMod, &unbond)
+				uDiff.Sub(uDiff, ub.Value)
 			}
 		}
 	}

--- a/icon/iiss/icstate/account.go
+++ b/icon/iiss/icstate/account.go
@@ -278,20 +278,25 @@ func (a *Account) GetUnbondingInfo(bonds Bonds, unbondingHeight int64) (Unbonds,
 					unbond := Unbond{nb.Address, diff, unbondingHeight}
 					ubToAdd = append(ubToAdd, &unbond)
 					uDiff.Add(uDiff, diff)
+				} else if diff.Sign() == 0 {
+					continue
 				}
 				for _, ub := range a.unbonds {
 					if nb.To().Equal(ub.Address) {
+						if len(ubToAdd) > 0 && nb.Address.Equal(ubToAdd[len(ubToAdd)-1].Address) {
+							ubToAdd = ubToAdd[:len(ubToAdd)-1]
+						}
 						value := new(big.Int).Add(ub.Value, diff)
 						if value.Sign() == -1 {
 							uDiff.Add(uDiff, value.Abs(value))
 							value = new(big.Int)
 						}
-						unbond := Unbond{nb.Address, value, unbondingHeight}
-						ubToMod = append(ubToMod, &unbond)
+						// append 0 value unbond to remove previous unbond
+						unbond := &Unbond{nb.Address, new(big.Int), ub.Expire}
+						ubToMod = append(ubToMod, unbond)
+						unbond = &Unbond{nb.Address, value, unbondingHeight}
+						ubToMod = append(ubToMod, unbond)
 						uDiff.Add(uDiff, diff)
-						if len(ubToAdd) > 0 && nb.Address.Equal(ubToAdd[len(ubToAdd)-1].Address) {
-							ubToAdd = ubToAdd[:len(ubToAdd)-1]
-						}
 					}
 				}
 			}
@@ -302,6 +307,19 @@ func (a *Account) GetUnbondingInfo(bonds Bonds, unbondingHeight int64) (Unbonds,
 				ubToMod = append(ubToMod, &unbond)
 				uDiff.Sub(uDiff, ub.Value)
 			}
+		}
+	}
+
+	for _, ob := range a.bonds {
+		exist := false
+		for _, nb := range bonds {
+			if nb.To().Equal(ob.To()) {
+				exist = true
+			}
+		}
+		if !exist {
+			ubToAdd = append(ubToAdd, &Unbond{ob.Address, ob.Amount(), unbondingHeight})
+			uDiff.Add(uDiff, ob.Amount())
 		}
 	}
 	return ubToAdd, ubToMod, uDiff

--- a/icon/iiss/icstate/account.go
+++ b/icon/iiss/icstate/account.go
@@ -345,6 +345,8 @@ func (a *Account) UpdateUnbonds(ubToAdd Unbonds, ubToMod Unbonds) []TimerJobInfo
 				ub.Expire = mod.Expire
 				if ub.Value.Cmp(new(big.Int)) == 0 {
 					tl = append(tl, TimerJobInfo{JobTypeRemove, ub.Expire})
+				} else {
+					tl = append(tl, TimerJobInfo{JobTypeAdd, ub.Expire})
 				}
 			}
 		}

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -209,8 +209,8 @@ func TestAccount_UpdateUnbonds(t *testing.T) {
 
 	expectedTL := []TimerJobInfo{{JobTypeAdd, ul2Add[0].Expire}, {JobTypeAdd, ul2Mod[0].Expire}}
 	assert.True(t, equalTimerJobSlice(expectedTL, tl))
-	ub1 := &Unbond{common.NewAddressFromString("hx5"), big.NewInt(40), 100}
-	ub2 := &Unbond{common.NewAddressFromString("hx6"), big.NewInt(10), 30}
+	ub1 := &Unbond{common.MustNewAddressFromString("hx5"), big.NewInt(40), 100}
+	ub2 := &Unbond{common.MustNewAddressFromString("hx6"), big.NewInt(10), 30}
 	assert.True(t, a.unbonds[0].Equal(ub1))
 	assert.True(t, a.unbonds[1].Equal(ub2))
 	assert.True(t, a.unbonds[2].Equal(add1))
@@ -399,7 +399,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
 	//case4 hx6 unbond will be modified(removed)
-	addr4 := common.NewAddressFromString("hx6")
+	addr4 := common.MustNewAddressFromString("hx6")
 	b1 = &Bond{addr1, common.NewHexInt(10)}
 	b2 = &Bond{addr2, common.NewHexInt(10)}
 	b3 = &Bond{addr3, common.NewHexInt(5)}
@@ -414,7 +414,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
 	//case5
-	b1 = &Bond{common.NewAddressFromString("hx10"), common.NewHexInt(100)}
+	b1 = &Bond{common.MustNewAddressFromString("hx10"), common.NewHexInt(100)}
 	nbs = []*Bond{b1}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) //hx3, hx4, hx5 will be added
 	expectedUDiff = big.NewInt(25)

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -345,6 +345,7 @@ func TestAccount_RemoveUnstaking(t *testing.T) {
 }
 
 func TestAccount_GetUnbondingInfo(t *testing.T) {
+	// case1 2 unbonds will added(for hx3, hx4)
 	a := assTest.Clone()
 	//bonds : [{hx3, 10}, {hx4, 10}] , unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
 	addr1 := common.NewAddressFromString("hx3")
@@ -364,6 +365,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.Equal(t, 0, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
+	// case2 hx5 unbond will be modified and hx4 unbond will be added
 	//add bond
 	addr3 := common.NewAddressFromString("hx5")
 	b1 = &Bond{addr3, common.NewHexInt(5)}
@@ -395,6 +397,18 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
 	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))
+	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
+
+	// hx6 unbond will be modified(removed)
+	addr4 := common.NewAddressFromString("hx6")
+	b1 = &Bond{addr4, common.NewHexInt(3)}
+	nbs = []*Bond{b1}
+	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh)
+	expectedUDiff = big.NewInt(-10)
+	ubMod1 = &Unbond{addr4, big.NewInt(0), bh}
+	assert.Equal(t, 0, len(ubAdds))
+	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 }

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -365,51 +365,70 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.Equal(t, 0, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
-	// case2 hx5 unbond will be modified and hx4 unbond will be added
+	// case2 hx5 unbond will be modified, hx4 unbond will be added
 	//add bond
 	addr3 := common.NewAddressFromString("hx5")
 	b1 = &Bond{addr3, common.NewHexInt(5)}
 	a.bonds = append(a.bonds, b1)
 	//bonds : [{hx3, 10}, {hx4, 10}, {hx5, 5}], unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
-	b1 = &Bond{addr2, common.NewHexInt(5)}
-	b2 = &Bond{addr3, common.NewHexInt(7)}
-	nbs = []*Bond{b1, b2}
+	b1 = &Bond{addr1, common.NewHexInt(10)}
+	b2 = &Bond{addr2, common.NewHexInt(5)}
+	b3 := &Bond{addr3, common.NewHexInt(7)}
+	nbs = []*Bond{b1, b2, b3}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) // 1 will modified(hx5), 1 will added(hx4)
 
 	expectedUDiff = big.NewInt(3)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
 	ubMod1 := &Unbond{addr3, big.NewInt(8), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
-	assert.True(t, ubMods[0].Equal(ubMod1))
+	assert.True(t, ubAdds[0].Equal(ubAdd1))
+	assert.True(t, ubMods[1].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))
-	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 2, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
+	//case3 hx5 will modified, hx will added
 	//bonds : [{hx3, 10}, {hx4, 10}, {hx5, 5}], unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
-	b1 = &Bond{addr2, common.NewHexInt(5)}
-	b2 = &Bond{addr3, common.NewHexInt(16)}
-	nbs = []*Bond{b1, b2}
+	b1 = &Bond{addr1, common.NewHexInt(10)}
+	b2 = &Bond{addr2, common.NewHexInt(5)}
+	b3 = &Bond{addr3, common.NewHexInt(16)}
+	nbs = []*Bond{b1, b2, b3}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) // 1 will modified(hx5), 1 will added(hx4)
 
 	expectedUDiff = big.NewInt(-5)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
 	ubMod1 = &Unbond{addr3, big.NewInt(0), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
-	assert.True(t, ubMods[0].Equal(ubMod1))
+	assert.True(t, ubAdds[0].Equal(ubAdd1))
+	assert.True(t, ubMods[1].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))
-	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 2, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
-	// hx6 unbond will be modified(removed)
+	//case4 hx6 unbond will be modified(removed)
 	addr4 := common.NewAddressFromString("hx6")
-	b1 = &Bond{addr4, common.NewHexInt(3)}
-	nbs = []*Bond{b1}
+	b1 = &Bond{addr1, common.NewHexInt(10)}
+	b2 = &Bond{addr2, common.NewHexInt(10)}
+	b3 = &Bond{addr3, common.NewHexInt(5)}
+	b4 := &Bond{addr4, common.NewHexInt(3)}
+	nbs = []*Bond{b1, b2, b3, b4}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh)
 	expectedUDiff = big.NewInt(-10)
 	ubMod1 = &Unbond{addr4, big.NewInt(0), bh}
 	assert.Equal(t, 0, len(ubAdds))
 	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
+
+	//case5
+	b1 = &Bond{common.NewAddressFromString("hx10"), common.NewHexInt(100)}
+	nbs = []*Bond{b1}
+	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) //hx3, hx4, hx5 will be added
+	expectedUDiff = big.NewInt(25)
+	assert.Equal(t, 3, len(ubAdds))
+	assert.True(t, ubAdds[0].Address.Equal(addr1))
+	assert.True(t, ubAdds[1].Address.Equal(addr2))
+	assert.True(t, ubAdds[2].Address.Equal(addr3))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 }
 

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -199,13 +199,6 @@ func TestAccount_UpdateUnstake(t *testing.T) {
 func TestAccount_UpdateUnbonds(t *testing.T) {
 	a := assTest.Clone() // unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
 
-	ub1 := &Unbond{common.NewAddressFromString("hx5"), big.NewInt(10), 20}
-	ub2 := &Unbond{common.NewAddressFromString("hx6"), big.NewInt(10), 30}
-	assert.True(t, a.unbonds[0].Equal(ub1))
-	assert.True(t, a.unbonds[1].Equal(ub2))
-	ua := big.NewInt(20)
-	assert.Equal(t, 0, ua.Cmp(a.unbonds.GetUnbondAmount()))
-
 	// modify hx5 targeted unbonding, add a unbonding(hx7)
 	// unbonds : [{address: hx5, value:40, bh: 100}, {hx6, 10, 30}, {hx7, 40, 50}]/
 	add1 := &Unbond{common.NewAddressFromString("hx7"), big.NewInt(40), 50}
@@ -214,14 +207,14 @@ func TestAccount_UpdateUnbonds(t *testing.T) {
 	ul2Mod := []*Unbond{mod1}
 	tl := a.UpdateUnbonds(ul2Add, ul2Mod)
 
-	expectedTL := []TimerJobInfo{{JobTypeAdd, ul2Add[0].Expire}}
+	expectedTL := []TimerJobInfo{{JobTypeAdd, ul2Add[0].Expire}, {JobTypeAdd, ul2Mod[0].Expire}}
 	assert.True(t, equalTimerJobSlice(expectedTL, tl))
-	ub1 = &Unbond{common.NewAddressFromString("hx5"), big.NewInt(40), 100}
-	ub2 = &Unbond{common.NewAddressFromString("hx6"), big.NewInt(10), 30}
+	ub1 := &Unbond{common.NewAddressFromString("hx5"), big.NewInt(40), 100}
+	ub2 := &Unbond{common.NewAddressFromString("hx6"), big.NewInt(10), 30}
 	assert.True(t, a.unbonds[0].Equal(ub1))
 	assert.True(t, a.unbonds[1].Equal(ub2))
 	assert.True(t, a.unbonds[2].Equal(add1))
-	ua = big.NewInt(90)
+	ua := big.NewInt(90)
 	assert.Equal(t, 0, ua.Cmp(a.unbonds.GetUnbondAmount()))
 
 	// delete hx5 targeted unbonding, add 2 unbondings(hx8, hx9)


### PR DESCRIPTION
* new unbond did not overwrite unbond when bond and unbond both exist before this commit
* delete unbond on setBond when bond does not exists, unbond exists
  - refer added test case
* remove previous unbond timer if unbond modifed
* add unbond when address exists in new bond and not in old bond
* return error if len(unbonds) > 1000