### PR TITLE
IC2-80: fix setBond

### DIFF
--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -34,6 +34,8 @@ import (
 	"github.com/icon-project/goloop/service/state"
 )
 
+const unbondingMax = 1000
+
 type ExtensionSnapshotImpl struct {
 	database db.Database
 
@@ -467,6 +469,10 @@ func (s *ExtensionStateImpl) SetBond(cc contract.CallContext, from module.Addres
 
 	account.SetBonds(bonds)
 	tl := account.UpdateUnbonds(ubToAdd, ubToMod)
+	unbondingCount := len(account.Unbonds())
+	if unbondingCount > unbondingMax {
+		return errors.Errorf("To many unbonds %d", unbondingCount)
+	}
 	for _, t := range tl {
 		ts := s.State.GetUnbondingTimer(t.Height, true)
 		if err = icstate.ScheduleTimerJob(ts, t, from); err != nil {

--- a/icon/iiss/icstate/account.go
+++ b/icon/iiss/icstate/account.go
@@ -297,17 +297,17 @@ func (a *Account) GetUnbondingInfo(bonds Bonds, unbondingHeight int64) (Unbonds,
 				for _, ub := range a.unbonds {
 					if nb.To().Equal(ub.Address) {
 						// append 0 value unbond to remove previous unbond
-						unbond := &Unbond{nb.Address, new(big.Int), ub.Expire}
+						unbond := &Unbond{nb.Address, new(big.Int), unbondingHeight}
 						ubToMod = append(ubToMod, unbond)
 						if diff.Sign() == -1 { // nb > ob, remove unbond
 							uDiff.Sub(uDiff, ub.Value)
-							break
 						} else { // modify unbond
 							ubToAdd = ubToAdd[:len(ubToAdd)-1]
 							value := new(big.Int).Add(ub.Value, diff)
 							unbond = &Unbond{nb.Address, value, unbondingHeight}
 							ubToAdd = append(ubToAdd, unbond)
 						}
+						break
 					}
 				}
 			}

--- a/icon/iiss/icstate/account.go
+++ b/icon/iiss/icstate/account.go
@@ -296,20 +296,18 @@ func (a *Account) GetUnbondingInfo(bonds Bonds, unbondingHeight int64) (Unbonds,
 				}
 				for _, ub := range a.unbonds {
 					if nb.To().Equal(ub.Address) {
-						if len(ubToAdd) > 0 && nb.Address.Equal(ubToAdd[len(ubToAdd)-1].Address) {
-							ubToAdd = ubToAdd[:len(ubToAdd)-1]
-						}
-						value := new(big.Int).Add(ub.Value, diff)
-						if value.Sign() == -1 {
-							uDiff.Add(uDiff, value.Abs(value))
-							value = new(big.Int)
-						}
 						// append 0 value unbond to remove previous unbond
 						unbond := &Unbond{nb.Address, new(big.Int), ub.Expire}
 						ubToMod = append(ubToMod, unbond)
-						unbond = &Unbond{nb.Address, value, unbondingHeight}
-						ubToMod = append(ubToMod, unbond)
-						uDiff.Add(uDiff, diff)
+						if diff.Sign() == -1 { // nb > ob, remove unbond
+							uDiff.Sub(uDiff, ub.Value)
+							break
+						} else { // modify unbond
+							ubToAdd = ubToAdd[:len(ubToAdd)-1]
+							value := new(big.Int).Add(ub.Value, diff)
+							unbond = &Unbond{nb.Address, value, unbondingHeight}
+							ubToAdd = append(ubToAdd, unbond)
+						}
 					}
 				}
 			}

--- a/icon/iiss/icstate/account.go
+++ b/icon/iiss/icstate/account.go
@@ -358,6 +358,8 @@ func (a *Account) UpdateUnbonds(ubToAdd Unbonds, ubToMod Unbonds) []TimerJobInfo
 				ub.Expire = mod.Expire
 				if ub.Value.Cmp(new(big.Int)) == 0 {
 					tl = append(tl, TimerJobInfo{JobTypeRemove, ub.Expire})
+				} else {
+					tl = append(tl, TimerJobInfo{JobTypeAdd, ub.Expire})
 				}
 			}
 		}

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -379,13 +379,13 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 
 	expectedUDiff = big.NewInt(7)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
-	ubAdd2 = &Unbond{addr3, big.NewInt(12), bh}
-	ubMod1 := &Unbond{addr3, new(big.Int), bh}
+	ubMod1 := &Unbond{addr3, new(big.Int), a.Unbonds()[0].Expire}
+	ubMod2 := &Unbond{addr3, big.NewInt(12), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
-	assert.True(t, ubAdds[1].Equal(ubAdd2))
 	assert.True(t, ubMods[0].Equal(ubMod1))
-	assert.Equal(t, 2, len(ubAdds))
-	assert.Equal(t, 1, len(ubMods))
+	assert.True(t, ubMods[1].Equal(ubMod2))
+	assert.Equal(t, 1, len(ubAdds))
+	assert.Equal(t, 2, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
 	//case3 hx4 will be added(5), hx5 will be removed
@@ -397,8 +397,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) // 1 will modified(hx5), 1 will added(hx4)
 
 	expectedUDiff = big.NewInt(-5)
-	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
-	ubMod1 = &Unbond{addr3, big.NewInt(0), bh}
+	ubMod1 = &Unbond{addr3, new(big.Int), a.Unbonds()[0].Expire}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
 	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -374,51 +374,70 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.Equal(t, 0, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
-	// case2 hx5 unbond will be modified and hx4 unbond will be added
+	// case2 hx5 unbond will be modified, hx4 unbond will be added
 	//add bond
 	addr3 := common.MustNewAddressFromString("hx5")
 	b1 = &Bond{addr3, common.NewHexInt(5)}
 	a.bonds = append(a.bonds, b1)
 	//bonds : [{hx3, 10}, {hx4, 10}, {hx5, 5}], unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
-	b1 = &Bond{addr2, common.NewHexInt(5)}
-	b2 = &Bond{addr3, common.NewHexInt(7)}
-	nbs = []*Bond{b1, b2}
+	b1 = &Bond{addr1, common.NewHexInt(10)}
+	b2 = &Bond{addr2, common.NewHexInt(5)}
+	b3 := &Bond{addr3, common.NewHexInt(7)}
+	nbs = []*Bond{b1, b2, b3}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) // 1 will modified(hx5), 1 will added(hx4)
 
 	expectedUDiff = big.NewInt(3)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
 	ubMod1 := &Unbond{addr3, big.NewInt(8), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
-	assert.True(t, ubMods[0].Equal(ubMod1))
+	assert.True(t, ubAdds[0].Equal(ubAdd1))
+	assert.True(t, ubMods[1].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))
-	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 2, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
+	//case3 hx5 will modified, hx will added
 	//bonds : [{hx3, 10}, {hx4, 10}, {hx5, 5}], unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
-	b1 = &Bond{addr2, common.NewHexInt(5)}
-	b2 = &Bond{addr3, common.NewHexInt(16)}
-	nbs = []*Bond{b1, b2}
+	b1 = &Bond{addr1, common.NewHexInt(10)}
+	b2 = &Bond{addr2, common.NewHexInt(5)}
+	b3 = &Bond{addr3, common.NewHexInt(16)}
+	nbs = []*Bond{b1, b2, b3}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) // 1 will modified(hx5), 1 will added(hx4)
 
 	expectedUDiff = big.NewInt(-5)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
 	ubMod1 = &Unbond{addr3, big.NewInt(0), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
-	assert.True(t, ubMods[0].Equal(ubMod1))
+	assert.True(t, ubAdds[0].Equal(ubAdd1))
+	assert.True(t, ubMods[1].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))
-	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 2, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
-	// hx6 unbond will be modified(removed)
+	//case4 hx6 unbond will be modified(removed)
 	addr4 := common.NewAddressFromString("hx6")
-	b1 = &Bond{addr4, common.NewHexInt(3)}
-	nbs = []*Bond{b1}
+	b1 = &Bond{addr1, common.NewHexInt(10)}
+	b2 = &Bond{addr2, common.NewHexInt(10)}
+	b3 = &Bond{addr3, common.NewHexInt(5)}
+	b4 := &Bond{addr4, common.NewHexInt(3)}
+	nbs = []*Bond{b1, b2, b3, b4}
 	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh)
 	expectedUDiff = big.NewInt(-10)
 	ubMod1 = &Unbond{addr4, big.NewInt(0), bh}
 	assert.Equal(t, 0, len(ubAdds))
 	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
+
+	//case5
+	b1 = &Bond{common.NewAddressFromString("hx10"), common.NewHexInt(100)}
+	nbs = []*Bond{b1}
+	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh) //hx3, hx4, hx5 will be added
+	expectedUDiff = big.NewInt(25)
+	assert.Equal(t, 3, len(ubAdds))
+	assert.True(t, ubAdds[0].Address.Equal(addr1))
+	assert.True(t, ubAdds[1].Address.Equal(addr2))
+	assert.True(t, ubAdds[2].Address.Equal(addr3))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 }
 

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -380,7 +380,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	expectedUDiff = big.NewInt(7)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
 	ubAdd2 = &Unbond{addr3, big.NewInt(12), bh}
-	ubMod1 := &Unbond{ addr3, new(big.Int), a.Unbonds()[0].Expire}
+	ubMod1 := &Unbond{addr3, new(big.Int), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
 	assert.True(t, ubAdds[1].Equal(ubAdd2))
 	assert.True(t, ubMods[0].Equal(ubMod1))
@@ -398,7 +398,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 
 	expectedUDiff = big.NewInt(-5)
 	ubAdd1 = &Unbond{addr2, big.NewInt(5), bh}
-	ubMod1 = &Unbond{addr3, big.NewInt(0), a.Unbonds()[0].Expire}
+	ubMod1 = &Unbond{addr3, big.NewInt(0), bh}
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
 	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))

--- a/icon/iiss/icstate/account_test.go
+++ b/icon/iiss/icstate/account_test.go
@@ -354,6 +354,7 @@ func TestAccount_RemoveUnstaking(t *testing.T) {
 }
 
 func TestAccount_GetUnbondingInfo(t *testing.T) {
+	// case1 2 unbonds will added(for hx3, hx4)
 	a := assTest.Clone()
 	//bonds : [{hx3, 10}, {hx4, 10}] , unbonds : [{address: hx5, value:10, bh: 20}, {hx6, 10, 30}]
 	addr1 := common.MustNewAddressFromString("hx3")
@@ -373,6 +374,7 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.Equal(t, 0, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 
+	// case2 hx5 unbond will be modified and hx4 unbond will be added
 	//add bond
 	addr3 := common.MustNewAddressFromString("hx5")
 	b1 = &Bond{addr3, common.NewHexInt(5)}
@@ -404,6 +406,18 @@ func TestAccount_GetUnbondingInfo(t *testing.T) {
 	assert.True(t, ubAdds[0].Equal(ubAdd1))
 	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubAdds))
+	assert.Equal(t, 1, len(ubMods))
+	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
+
+	// hx6 unbond will be modified(removed)
+	addr4 := common.NewAddressFromString("hx6")
+	b1 = &Bond{addr4, common.NewHexInt(3)}
+	nbs = []*Bond{b1}
+	ubAdds, ubMods, uDiff = a.GetUnbondingInfo(nbs, bh)
+	expectedUDiff = big.NewInt(-10)
+	ubMod1 = &Unbond{addr4, big.NewInt(0), bh}
+	assert.Equal(t, 0, len(ubAdds))
+	assert.True(t, ubMods[0].Equal(ubMod1))
 	assert.Equal(t, 1, len(ubMods))
 	assert.Equal(t, 0, uDiff.Cmp(expectedUDiff))
 }


### PR DESCRIPTION
* new unbond did not overwrite unbond when bond and unbond both exist before this commit
* delete unbond on setBond when bond does not exists, unbond exists
* remove previous unbond timer if unbond modifed
* add unbond when address exists in new bond and not in old bond
* return error if len(unbond) > 1000


