### PR TITLE
Use common.HexInt instead of jsonrpc.HexInt

### DIFF
--- a/client/clientv3.go
+++ b/client/clientv3.go
@@ -168,8 +168,8 @@ func (c *ClientV3) Call(param *v3.CallParam) (interface{}, error) {
 	return result, nil
 }
 
-func (c *ClientV3) GetBalance(param *v3.AddressParam) (*jsonrpc.HexInt, error) {
-	var result jsonrpc.HexInt
+func (c *ClientV3) GetBalance(param *v3.AddressParam) (*common.HexInt, error) {
+	var result common.HexInt
 	_, err := c.Do("icx_getBalance", param, &result)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using jsonrpc.HexInt as result for getBalance which doesn't provide a correct result of the  jsonrpc.HexInt.Value function.
Ex: my wallet has 2001ICX ~ 2001000000000000000000Wei. it leads to Int64, uint64 is not enought for output the Hex string value. So if I call jsonrpc.HexInt.Value() it always show zero.

```
	c := client.NewClientV3("https://bicon.net.solidwallet.io/api/v3")
	b, err := c.GetBalance(&v3.AddressParam{
		Address: jsonrpc.Address("hxe562fa536414648d0ff67b50d16c9fefcf4524e2"),
	})
	if err != nil {
		fmt.Println(err)
	}
	fmt.Println(b.Value())
```

I would like to suggest to use common.HexInt instead.

