### PR TITLE
Feature/ic2 83 query after unregister prep

### DIFF
--- a/icon/iiss/prepmanager.go
+++ b/icon/iiss/prepmanager.go
@@ -410,6 +410,9 @@ func (pm *PRepManager) RegisterPRep(regInfo *RegInfo, irep *big.Int) error {
 	if ps := pm.state.GetPRepStatus(owner, false); ps != nil {
 		if ps.Status() != icstate.NotReady {
 			return errors.Errorf("Already in use: addr=%s status=%s", owner, ps.Status())
+		} else {
+			// if status is NotReady
+			pm.totalDelegated.Add(pm.totalDelegated, ps.Delegated())
 		}
 	}
 
@@ -542,9 +545,8 @@ func (pm *PRepManager) ChangeDelegation(od, nd icstate.Delegations) (map[string]
 		}
 		if value.Sign() != 0 {
 			ps := pm.state.GetPRepStatus(owner, true)
-			if ps.IsActive() {
-				ps.Delegated().Add(ps.Delegated(), value)
-			} else {
+			ps.Delegated().Add(ps.Delegated(), value)
+			if !ps.IsActive() {
 				delegatedToInactiveNode.Add(delegatedToInactiveNode, value)
 			}
 		}
@@ -591,6 +593,7 @@ func (pm *PRepManager) ChangeBond(oBonds, nBonds icstate.Bonds) (map[string]*big
 			if ps.IsActive() {
 				ps.Bonded().Add(ps.Bonded(), value)
 			} else {
+				// this code is not reachable, because there is no case of bonding to not-registered PRep
 				bondedToInactiveNode.Add(bondedToInactiveNode, value)
 			}
 		}

--- a/icon/iiss/prepmanager.go
+++ b/icon/iiss/prepmanager.go
@@ -407,13 +407,9 @@ func (pm *PRepManager) RegisterPRep(regInfo *RegInfo, irep *big.Int) error {
 	if pm.contains(owner) {
 		return errors.Errorf("PRep already exists: %s", owner)
 	}
-	if ps := pm.state.GetPRepStatus(owner, false); ps != nil {
-		if ps.Status() != icstate.NotReady {
-			return errors.Errorf("Already in use: addr=%s status=%s", owner, ps.Status())
-		} else {
-			// if status is NotReady
-			pm.totalDelegated.Add(pm.totalDelegated, ps.Delegated())
-		}
+	ps := pm.state.GetPRepStatus(owner, false)
+	if ps != nil && ps.Status() != icstate.NotReady {
+		return errors.Errorf("Already in use: addr=%s status=%s", owner, ps.Status())
 	}
 
 	pb := pm.state.GetPRepBase(owner, true)
@@ -423,7 +419,9 @@ func (pm *PRepManager) RegisterPRep(regInfo *RegInfo, irep *big.Int) error {
 	}
 	pb.SetIrep(irep, 0)
 
-	ps := pm.state.GetPRepStatus(owner, true)
+	if ps == nil {
+		ps = pm.state.GetPRepStatus(owner, true)
+	}
 	ps.SetStatus(icstate.Active)
 
 	pm.state.AddActivePRep(owner)

--- a/icon/iiss/prepmanager_test.go
+++ b/icon/iiss/prepmanager_test.go
@@ -244,7 +244,7 @@ func TestPRepManager_disablePRep(t *testing.T) {
 		assert.NoError(t, err)
 
 		noPRep := pm.GetPRepByOwner(owner)
-		assert.Nil(t, noPRep)
+		assert.NotNil(t, noPRep)
 
 		assert.Equal(t, size-i-1, pm.Size())
 

--- a/icon/iiss/prepmanager_test.go
+++ b/icon/iiss/prepmanager_test.go
@@ -221,6 +221,34 @@ func TestPRepManager_RegisterPRep(t *testing.T) {
 	assert.True(t, checkOrderedByBondedDelegation(pm, 5))
 }
 
+func TestPRepManager_RegisterPRepWithNotReadyPRep(t *testing.T) {
+	size := 5
+	start := 10
+	br := int64(5)
+	pm := createPRepManager(t, false, 0)
+
+	nd, sum := createDelegations(start, size)
+	delta, err := pm.ChangeDelegation(nil, nd)
+	assert.NoError(t, err)
+	etd := big.NewInt(sum)
+	td := new(big.Int)
+	for _, value := range delta {
+		assert.True(t, value.Sign() >= 0)
+		td.Add(td, value)
+	}
+	assert.Zero(t, etd.Cmp(td))
+
+	for i := 0; i < size; i++ {
+		regInfo := newRegInfo(start + i)
+		err = pm.RegisterPRep(regInfo, BigIntInitialIRep)
+		assert.NoError(t, err)
+	}
+
+	assert.Zero(t, etd.Cmp(pm.TotalDelegated()))
+	assert.Equal(t, int64(0), pm.TotalBonded().Int64())
+	checkOrderedByBondedDelegation(pm, br)
+}
+
 func TestPRepManager_disablePRep(t *testing.T) {
 	size := 5
 	pm := createPRepManager(t, false, size)


### PR DESCRIPTION
- PRep information remains in PRepMap
- unregister PRep adjusts status as "Unregistered"
- getPRep can query the unregistered PRep information

- When delegating to not-register PRep, PrepManager should write delegation value to Prep status.
- TotalDelegated value of PRepManger should be adjusted accordingly.

Relevant test code is written in test_PREP.py::TestUnregisterPRep