### PR TITLE
Migrate FIX_TOTAL_ELECTED_PREP_DELEGATED revision

### DIFF
--- a/icon/icmodule/revision.go
+++ b/icon/icmodule/revision.go
@@ -47,6 +47,8 @@ const (
 
 	RevisionDecentralize = Revision6
 
+	RevisionFixTotalDelegated = Revision7
+
 	RevisionFixBurnEventSignature = Revision9
 
 	RevisionBurnV2 = Revision12

--- a/icon/iiss/calculator.go
+++ b/icon/iiss/calculator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/icon-project/goloop/common/intconv"
 	"github.com/icon-project/goloop/common/log"
 	"github.com/icon-project/goloop/common/trie"
+	"github.com/icon-project/goloop/icon/icmodule"
 	"github.com/icon-project/goloop/icon/iiss/icobject"
 	"github.com/icon-project/goloop/icon/iiss/icreward"
 	"github.com/icon-project/goloop/icon/iiss/icstage"
@@ -404,7 +405,10 @@ func (c *Calculator) calculateVotedReward() error {
 
 			obj := icstage.ToEventEnable(o)
 			vInfo.setEnable(obj.Target, obj.Flag)
-			vInfo.updateTotalBondedDelegation()
+			// If revision < 7, do not update totalBondedDelegation with EventEnable
+			if c.global.GetRevision() >= icmodule.Revision7 {
+				vInfo.updateTotalBondedDelegation()
+			}
 		case icstage.TypeEventDelegation:
 			obj := icstage.ToEventVote(o)
 			vInfo.updateDelegated(obj.Votes)

--- a/icon/iiss/calculator.go
+++ b/icon/iiss/calculator.go
@@ -406,7 +406,7 @@ func (c *Calculator) calculateVotedReward() error {
 			obj := icstage.ToEventEnable(o)
 			vInfo.setEnable(obj.Target, obj.Flag)
 			// If revision < 7, do not update totalBondedDelegation with EventEnable
-			if c.global.GetRevision() >= icmodule.Revision7 {
+			if c.global.GetRevision() >= icmodule.RevisionFixTotalDelegated {
 				vInfo.updateTotalBondedDelegation()
 			}
 		case icstage.TypeEventDelegation:

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -233,6 +233,7 @@ func (s *ExtensionStateImpl) NewCalculation(term *icstate.Term, calculator *Calc
 	switch iissVersion {
 	case icstate.IISSVersion1:
 		if err = s.Back.AddGlobalV1(
+			term.Revision(),
 			term.StartHeight(),
 			int(term.Period()-1),
 			term.Irep(),
@@ -244,6 +245,7 @@ func (s *ExtensionStateImpl) NewCalculation(term *icstate.Term, calculator *Calc
 		}
 	case icstate.IISSVersion2:
 		if err = s.Back.AddGlobalV2(
+			term.Revision(),
 			term.StartHeight(),
 			int(term.Period()-1),
 			term.Iglobal(),

--- a/icon/iiss/icstage/global.go
+++ b/icon/iiss/icstage/global.go
@@ -38,6 +38,7 @@ type Global interface {
 	GetStartHeight() int64
 	GetOffsetLimit() int
 	GetTermPeriod() int
+	GetRevision() int
 	GetElectedPRepCount() int
 	GetBondRequirement() int
 	String() string
@@ -59,6 +60,7 @@ type GlobalV1 struct {
 	IISSVersion      int
 	StartHeight      int64
 	OffsetLimit      int
+	Revision         int
 	Irep             *big.Int
 	Rrep             *big.Int
 	MainPRepCount    int
@@ -85,6 +87,10 @@ func (g *GlobalV1) GetTermPeriod() int {
 	return g.OffsetLimit + 1
 }
 
+func (g *GlobalV1) GetRevision() int {
+	return g.Revision
+}
+
 func (g *GlobalV1) GetElectedPRepCount() int {
 	return g.ElectedPRepCount
 }
@@ -98,6 +104,7 @@ func (g *GlobalV1) RLPDecodeFields(decoder codec.Decoder) error {
 		&g.IISSVersion,
 		&g.StartHeight,
 		&g.OffsetLimit,
+		&g.Revision,
 		&g.Irep,
 		&g.Rrep,
 		&g.MainPRepCount,
@@ -111,6 +118,7 @@ func (g *GlobalV1) RLPEncodeFields(encoder codec.Encoder) error {
 		g.IISSVersion,
 		g.StartHeight,
 		g.OffsetLimit,
+		g.Revision,
 		g.Irep,
 		g.Rrep,
 		g.MainPRepCount,
@@ -119,8 +127,9 @@ func (g *GlobalV1) RLPEncodeFields(encoder codec.Encoder) error {
 }
 
 func (g *GlobalV1) String() string {
-	return fmt.Sprintf("IISSVersion: %d, StartHeight: %d, OffsetLimit: %d, Irep: %s, Rrep: %s, "+
+	return fmt.Sprintf("Revision: %d, IISSVersion: %d, StartHeight: %d, OffsetLimit: %d, Irep: %s, Rrep: %s, "+
 		"MainPRepCount: %d, ElectedPRepCount: %d",
+		g.Revision,
 		g.IISSVersion,
 		g.StartHeight,
 		g.OffsetLimit,
@@ -136,6 +145,7 @@ func (g *GlobalV1) Equal(impl icobject.Impl) bool {
 		return g.IISSVersion == g2.IISSVersion &&
 			g.StartHeight == g2.StartHeight &&
 			g.OffsetLimit == g2.OffsetLimit &&
+			g.Revision == g2.Revision &&
 			g.Irep.Cmp(g2.Irep) == 0 &&
 			g.Rrep.Cmp(g2.Rrep) == 0 &&
 			g.MainPRepCount == g2.MainPRepCount &&
@@ -149,6 +159,7 @@ func (g *GlobalV1) Clear() {
 	g.IISSVersion = 0
 	g.StartHeight = 0
 	g.OffsetLimit = 0
+	g.Revision = 0
 	g.Irep.SetInt64(0)
 	g.Rrep.SetInt64(0)
 	g.MainPRepCount = 0
@@ -183,6 +194,7 @@ type GlobalV2 struct {
 	IISSVersion      int
 	StartHeight      int64
 	OffsetLimit      int
+	Revision         int
 	Iglobal          *big.Int
 	Iprep            *big.Int
 	Ivoter           *big.Int
@@ -210,6 +222,10 @@ func (g *GlobalV2) GetTermPeriod() int {
 	return g.OffsetLimit + 1
 }
 
+func (g *GlobalV2) GetRevision() int {
+	return g.Revision
+}
+
 func (g *GlobalV2) GetElectedPRepCount() int {
 	return g.ElectedPRepCount
 }
@@ -223,6 +239,7 @@ func (g *GlobalV2) RLPDecodeFields(decoder codec.Decoder) error {
 		&g.IISSVersion,
 		&g.StartHeight,
 		&g.OffsetLimit,
+		&g.Revision,
 		&g.Iglobal,
 		&g.Iprep,
 		&g.Ivoter,
@@ -237,6 +254,7 @@ func (g *GlobalV2) RLPEncodeFields(encoder codec.Encoder) error {
 		g.IISSVersion,
 		g.StartHeight,
 		g.OffsetLimit,
+		g.Revision,
 		g.Iglobal,
 		g.Iprep,
 		g.Ivoter,
@@ -246,8 +264,9 @@ func (g *GlobalV2) RLPEncodeFields(encoder codec.Encoder) error {
 }
 
 func (g *GlobalV2) String() string {
-	return fmt.Sprintf("IISSVersion: %d, StartHeight: %d, OffsetLimit: %d, Iglobal: %s, Iprep: %s, "+
-		"Ivoter: %d, ElectedPRepCount: %d, BondRequirement: %d",
+	return fmt.Sprintf("Revision: %d, IISSVersion: %d, StartHeight: %d, OffsetLimit: %d, Iglobal: %s, "+
+		"Iprep: %s, Ivoter: %d, ElectedPRepCount: %d, BondRequirement: %d",
+		g.Revision,
 		g.IISSVersion,
 		g.StartHeight,
 		g.OffsetLimit,
@@ -264,6 +283,7 @@ func (g *GlobalV2) Equal(impl icobject.Impl) bool {
 		return g.IISSVersion == g2.IISSVersion &&
 			g.StartHeight == g2.StartHeight &&
 			g.OffsetLimit == g2.OffsetLimit &&
+			g.Revision == g2.Revision &&
 			g.Iglobal.Cmp(g2.Iglobal) == 0 &&
 			g.Iprep.Cmp(g2.Iprep) == 0 &&
 			g.Ivoter.Cmp(g2.Ivoter) == 0 &&
@@ -278,6 +298,7 @@ func (g *GlobalV2) Clear() {
 	g.IISSVersion = 0
 	g.StartHeight = 0
 	g.OffsetLimit = 0
+	g.Revision = 0
 	g.Iglobal = new(big.Int)
 	g.Iprep = new(big.Int)
 	g.Ivoter = new(big.Int)

--- a/icon/iiss/icstage/state.go
+++ b/icon/iiss/icstage/state.go
@@ -198,9 +198,12 @@ func (s *State) addValidator(offset int, validator module.Address) error {
 	return err
 }
 
-func (s *State) AddGlobalV1(startHeight int64, offsetLimit int, irep *big.Int, rrep *big.Int, mainPRepCount int, electedPRepCount int) error {
+func (s *State) AddGlobalV1(revision int, startHeight int64, offsetLimit int, irep *big.Int, rrep *big.Int,
+	mainPRepCount int, electedPRepCount int,
+) error {
 	key := HashKey.Append(globalKey).Build()
 	g := newGlobalV1()
+	g.Revision = revision
 	g.IISSVersion = icstate.IISSVersion1
 	g.StartHeight = startHeight
 	g.OffsetLimit = offsetLimit
@@ -212,11 +215,12 @@ func (s *State) AddGlobalV1(startHeight int64, offsetLimit int, irep *big.Int, r
 	return err
 }
 
-func (s *State) AddGlobalV2(startHeight int64, offsetLimit int, iglobal *big.Int, iprep *big.Int, ivoter *big.Int,
-	electedPRepCount int, bondRequirement int,
+func (s *State) AddGlobalV2(revision int, startHeight int64, offsetLimit int, iglobal *big.Int, iprep *big.Int,
+	ivoter *big.Int, electedPRepCount int, bondRequirement int,
 ) error {
 	key := HashKey.Append(globalKey).Build()
 	g := newGlobalV2()
+	g.Revision = revision
 	g.IISSVersion = icstate.IISSVersion2
 	g.StartHeight = startHeight
 	g.OffsetLimit = offsetLimit

--- a/icon/iiss/icstage/state_test.go
+++ b/icon/iiss/icstage/state_test.go
@@ -378,6 +378,7 @@ func TestState_AddGlobal(t *testing.T) {
 	s := NewStateFromSnapshot(NewSnapshot(database, nil))
 
 	type args struct {
+		revision         int
 		version          int
 		startHeight      int64
 		offsetLimit      int
@@ -399,6 +400,7 @@ func TestState_AddGlobal(t *testing.T) {
 		{
 			"Version 1",
 			args{
+				revision:         4,
 				version:          GlobalVersion1,
 				startHeight:      0,
 				offsetLimit:      1000,
@@ -411,6 +413,7 @@ func TestState_AddGlobal(t *testing.T) {
 		{
 			"Version 2",
 			args{
+				revision:         13,
 				version:          GlobalVersion2,
 				startHeight:      0,
 				offsetLimit:      1000,
@@ -429,6 +432,7 @@ func TestState_AddGlobal(t *testing.T) {
 			switch a.version {
 			case GlobalVersion1:
 				err = s.AddGlobalV1(
+					a.revision,
 					a.startHeight,
 					a.offsetLimit,
 					a.irep,
@@ -438,6 +442,7 @@ func TestState_AddGlobal(t *testing.T) {
 				)
 			case GlobalVersion2:
 				err = s.AddGlobalV2(
+					a.revision,
 					a.startHeight,
 					a.offsetLimit,
 					a.iglobal,
@@ -460,6 +465,7 @@ func TestState_AddGlobal(t *testing.T) {
 				global := g.GetV1()
 				assert.NotNil(t, global)
 				assert.Equal(t, a.version, global.Version())
+				assert.Equal(t, a.revision, global.GetRevision())
 				assert.Equal(t, a.offsetLimit, global.OffsetLimit)
 				assert.Equal(t, 0, a.irep.Cmp(global.Irep))
 				assert.Equal(t, 0, a.rrep.Cmp(global.Rrep))
@@ -469,6 +475,7 @@ func TestState_AddGlobal(t *testing.T) {
 				global := g.GetV2()
 				assert.NotNil(t, global)
 				assert.Equal(t, a.version, global.Version())
+				assert.Equal(t, a.revision, global.GetRevision())
 				assert.Equal(t, a.offsetLimit, global.OffsetLimit)
 				assert.Equal(t, 0, a.iglobal.Cmp(global.Iglobal))
 				assert.Equal(t, 0, a.iprep.Cmp(global.Iprep))


### PR DESCRIPTION
- add GetRevision() to icstage.Global interface
- If revision < FIX_TOTAL_ELECTED_PREP_DELEGATED, do not update votedInfo.totalBondedDelegation with EventEnable