### PR TITLE
Add replay of ICON1 delegation bug

### DIFF
--- a/cmd/lcimport/state.go
+++ b/cmd/lcimport/state.go
@@ -341,11 +341,12 @@ func applyShortcut(scs map[string]shortcut, params []string) []string {
 }
 
 var extensionStateShortcuts = map[string]shortcut{
-	"prep_base":   {[]string{"dict", "prep_base"}, []string{"obj"}},   // <address>
-	"prep_status": {[]string{"dict", "prep_status"}, []string{"obj"}}, // <address>
-	"active_prep": {[]string{"array", "active_prep"}, []string{"addr"}},
-	"account":     {[]string{"dict", "account_db"}, []string{"obj"}}, // <address>
-	"value":       {[]string{"var"}, []string{}},                     // <name>
+	"prep_base":     {[]string{"dict", "prep_base"}, []string{"obj"}},   // <address>
+	"prep_status":   {[]string{"dict", "prep_status"}, []string{"obj"}}, // <address>
+	"active_prep":   {[]string{"array", "active_prep"}, []string{"addr"}},
+	"account":       {[]string{"dict", "account_db"}, []string{"obj"}},     // <address>
+	"value":         {[]string{"var"}, []string{}},                         // <name>
+	"delegationBug": {[]string{"dict", "delegation_bug"}, []string{"obj"}}, // <address>
 }
 
 var extensionStageShortcuts = map[string]shortcut{

--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -230,10 +230,10 @@ func (s *chainScore) Ex_setDelegation(param []interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err = es.SetDelegation(s.cc.BlockHeight(), s.from, ds); err != nil {
+	revision := s.cc.Revision().Value()
+	if err = es.SetDelegation(s.cc.BlockHeight(), s.from, ds, revision); err != nil {
 		return err
 	}
-	revision := s.cc.Revision().Value()
 	if icmodule.RevisionMultipleUnstakes <= revision && revision < icmodule.RevisionFixInvalidUnstake {
 		migrate.ReproduceUnstakeBugForDelegation(s.cc, s.log)
 	}

--- a/icon/iiss/icstage/event.go
+++ b/icon/iiss/icstage/event.go
@@ -24,6 +24,7 @@ import (
 	"github.com/icon-project/goloop/common/codec"
 	"github.com/icon-project/goloop/common/errors"
 	"github.com/icon-project/goloop/icon/iiss/icobject"
+	"github.com/icon-project/goloop/icon/iiss/icstate"
 	"github.com/icon-project/goloop/icon/iiss/icutils"
 	"github.com/icon-project/goloop/module"
 )
@@ -164,6 +165,17 @@ func (vl VoteList) ToMap() map[string]*Vote {
 		m[icutils.ToKey(v.To())] = v
 	}
 	return m
+}
+
+func NewVoteListFromDelegations(delegations icstate.Delegations) VoteList {
+	var newVL VoteList
+
+	for _, d := range delegations {
+		vote := NewVote(common.AddressToPtr(d.To()), new(big.Int).Neg(d.Amount()))
+		newVL = append(newVL, vote)
+	}
+
+	return newVL
 }
 
 type EventVote struct {

--- a/icon/iiss/icstate/bond.go
+++ b/icon/iiss/icstate/bond.go
@@ -125,6 +125,22 @@ func (bs *Bonds) Equal(bl2 Bonds) bool {
 	return true
 }
 
+func (bs *Bonds) Delta(bl2 Bonds) map[string]*big.Int {
+	delta := make(map[string]*big.Int)
+	for _, bond := range *bs {
+		key := icutils.ToKey(bond.To())
+		delta[key] = new(big.Int).Neg(bond.Amount())
+	}
+	for _, bond := range bl2 {
+		key := icutils.ToKey(bond.To())
+		if delta[key] == nil {
+			delta[key] = new(big.Int)
+		}
+		delta[key].Add(delta[key], bond.Amount())
+	}
+	return delta
+}
+
 func (bs *Bonds) Clone() Bonds {
 	if *bs == nil {
 		return nil

--- a/icon/iiss/icstate/delegation.go
+++ b/icon/iiss/icstate/delegation.go
@@ -118,6 +118,23 @@ func (ds Delegations) Equal(ds2 Delegations) bool {
 	return true
 }
 
+func (ds Delegations) Delta(ds2 Delegations) map[string]*big.Int {
+	delta := make(map[string]*big.Int)
+
+	for _, d := range ds {
+		key := icutils.ToKey(d.To())
+		delta[key] = new(big.Int).Neg(d.Amount())
+	}
+	for _, d := range ds2 {
+		key := icutils.ToKey(d.To())
+		if delta[key] == nil {
+			delta[key] = new(big.Int)
+		}
+		delta[key].Add(delta[key], d.Amount())
+	}
+	return delta
+}
+
 func (ds Delegations) GetDelegationAmount() *big.Int {
 	total := new(big.Int)
 	for _, d := range ds {

--- a/icon/iiss/icstate/delegationbug.go
+++ b/icon/iiss/icstate/delegationbug.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021 ICON Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package icstate
+
+import (
+	"fmt"
+
+	"github.com/icon-project/goloop/common"
+	"github.com/icon-project/goloop/common/codec"
+	"github.com/icon-project/goloop/common/containerdb"
+	"github.com/icon-project/goloop/icon/iiss/icobject"
+	"github.com/icon-project/goloop/module"
+	"github.com/icon-project/goloop/service/scoredb"
+)
+
+var DelegationBugPrefix = containerdb.ToKey(
+	containerdb.HashBuilder,
+	scoredb.DictDBPrefix,
+	"delegation_bug",
+)
+
+type DelegationBug struct {
+	icobject.NoDatabase
+
+	address     *common.Address
+	blockHeight int64
+	delegations Delegations
+}
+
+func NewDelegationBugWithTag(_ icobject.Tag) *DelegationBug {
+	return new(DelegationBug)
+}
+
+func NewDelegationBug(addr module.Address, height int64, ds Delegations) *DelegationBug {
+	return &DelegationBug{
+		address:     common.AddressToPtr(addr),
+		blockHeight: height,
+		delegations: ds,
+	}
+}
+
+func (d *DelegationBug) Version() int {
+	return 1
+}
+
+func (d *DelegationBug) Address() module.Address {
+	return d.address
+}
+
+func (d *DelegationBug) BlockHeight() int64 {
+	return d.blockHeight
+}
+
+func (d *DelegationBug) Delegations() Delegations {
+	return d.delegations
+}
+
+func (d *DelegationBug) RLPDecodeFields(decoder codec.Decoder) error {
+	return decoder.DecodeAll(
+		&d.address,
+		&d.blockHeight,
+		&d.delegations,
+	)
+}
+
+func (d *DelegationBug) RLPEncodeFields(encoder codec.Encoder) error {
+	return encoder.EncodeMulti(
+		d.address,
+		d.blockHeight,
+		d.delegations,
+	)
+}
+
+func (d *DelegationBug) Equal(o icobject.Impl) bool {
+	if d2, ok := o.(*DelegationBug); ok {
+		return d.address.Equal(d2.address) &&
+			d.blockHeight == d2.blockHeight &&
+			d.delegations.Equal(d2.delegations)
+	} else {
+		return false
+	}
+}
+
+
+func (d *DelegationBug) Format(f fmt.State, c rune) {
+	switch c {
+	case 'v':
+		if f.Flag('+') {
+			fmt.Fprintf(f, "DelegationBug{address=%s blockHeight=%d delegations=%+v}",
+				d.address, d.blockHeight, d.delegations)
+		} else {
+			fmt.Fprintf(f, "DelegationBug{%s %d %v}", d.address, d.blockHeight, d.delegations)
+		}
+	}
+}

--- a/icon/iiss/icstate/object.go
+++ b/icon/iiss/icstate/object.go
@@ -32,6 +32,7 @@ const (
 	TypeRewardCalcInfo
 	TypeValidators
 	TypeBlockVoters
+	TypeDelegationBug
 )
 
 type StateAndSnapshot struct {
@@ -72,6 +73,8 @@ func NewObjectImpl(tag icobject.Tag) (icobject.Impl, error) {
 		return newValidatorsWithTag(tag), nil
 	case TypeBlockVoters:
 		return NewBlockVotersWithTag(tag), nil
+	case TypeDelegationBug:
+		return NewDelegationBugWithTag(tag), nil
 	default:
 		return nil, errors.IllegalArgumentError.Errorf(
 			"UnknownTypeTag(tag=%#x)", tag)
@@ -142,4 +145,11 @@ func ToBlockVoters(object trie.Object) *BlockVotersSnapshot {
 		return nil
 	}
 	return object.(*icobject.Object).Real().(*BlockVotersSnapshot)
+}
+
+func ToDelegationBug(object trie.Object) *DelegationBug {
+	if object == nil {
+		return nil
+	}
+	return object.(*icobject.Object).Real().(*DelegationBug)
 }

--- a/icon/iiss/icstate/state.go
+++ b/icon/iiss/icstate/state.go
@@ -708,3 +708,23 @@ func (s *State) GetUnstakeLockPeriod(revision int, totalSupply *big.Int) int64 {
 
 	return CalcUnstakeLockPeriod(lMin, lMax, totalStake, totalSupply)
 }
+
+func (s *State) AddDelegationBug(d *DelegationBug) error {
+	dict := containerdb.NewDictDB(s.store, 1, DelegationBugPrefix)
+	o := icobject.New(TypeDelegationBug, d)
+	return dict.Set(d.Address(), o)
+}
+
+func (s *State) DeleteDelegationBug(addr module.Address) error {
+	dict := containerdb.NewDictDB(s.store, 1, DelegationBugPrefix)
+	return dict.Delete(addr)
+}
+
+func (s *State) GetDelegationBug(addr module.Address) *DelegationBug {
+	dict := containerdb.NewDictDB(s.store, 1, DelegationBugPrefix)
+	obj := dict.Get(addr)
+	if obj == nil {
+		return nil
+	}
+	return ToDelegationBug(obj.Object())
+}

--- a/icon/iiss/prepmanager.go
+++ b/icon/iiss/prepmanager.go
@@ -19,20 +19,7 @@ type PRepManager struct {
 }
 
 func (pm *PRepManager) ChangeDelegation(od, nd icstate.Delegations) (map[string]*big.Int, error) {
-	delta := make(map[string]*big.Int)
-
-	for _, d := range od {
-		key := icutils.ToKey(d.To())
-		delta[key] = new(big.Int).Neg(d.Amount())
-	}
-	for _, d := range nd {
-		key := icutils.ToKey(d.To())
-		if delta[key] == nil {
-			delta[key] = new(big.Int)
-		}
-		delta[key].Add(delta[key], d.Amount())
-	}
-
+	delta := od.Delta(nd)
 	delegatedToInactiveNode := big.NewInt(0)
 	for key, value := range delta {
 		owner, err := common.NewAddress([]byte(key))
@@ -64,20 +51,7 @@ func (pm *PRepManager) ChangeDelegation(od, nd icstate.Delegations) (map[string]
 }
 
 func (pm *PRepManager) ChangeBond(oBonds, nBonds icstate.Bonds) (map[string]*big.Int, error) {
-	delta := make(map[string]*big.Int)
-
-	for _, bond := range oBonds {
-		key := icutils.ToKey(bond.To())
-		delta[key] = new(big.Int).Neg(bond.Amount())
-	}
-	for _, bond := range nBonds {
-		key := icutils.ToKey(bond.To())
-		if delta[key] == nil {
-			delta[key] = new(big.Int)
-		}
-		delta[key].Add(delta[key], bond.Amount())
-	}
-
+	delta := oBonds.Delta(nBonds)
 	bondedToInactiveNode := big.NewInt(0)
 	for key, value := range delta {
 		owner, err := common.NewAddress([]byte(key))

--- a/service/contract/callcontext.go
+++ b/service/contract/callcontext.go
@@ -446,6 +446,9 @@ func (cc *callContext) Dispose() {
 	if cc.executor != nil {
 		cc.executor.Release()
 	}
+	if cc.GetExtensionState() != nil {
+		cc.GetExtensionState().Release()
+	}
 }
 
 func (cc *callContext) StepUsed() *big.Int {

--- a/service/state/extension.go
+++ b/service/state/extension.go
@@ -25,6 +25,7 @@ type ExtensionSnapshot interface {
 type ExtensionState interface {
 	GetSnapshot() ExtensionSnapshot
 	Reset(snapshot ExtensionSnapshot)
+	Release()
 	ClearCache()
 }
 
@@ -46,6 +47,12 @@ func (n *extensionStateHolder) Reset(snapshot ExtensionSnapshot) {
 		if snapshot != nil {
 			n.state = snapshot.NewState(false)
 		}
+	}
+}
+
+func (n *extensionStateHolder) Release() {
+	if n.state != nil {
+		n.state.Release()
 	}
 }
 


### PR DESCRIPTION
ICON1 setDelegation bug
- Add EventDelegation to Front when TX was failed

To replay setDelegation bug of ICON1
- Add Release() to ExtensionState interface. Release() called at callContext.Dispose()
- Save delegation data to extensionState in memory and freed after executing TX
- Write delegation data of failed TX to ext.State.DelegationBug and ext.Front.EventDelegation at Reset()
- ext.State.DelegationBug will be removed when setDelegation succeed
- Make EventDelegation with ext.State.Account.delegations and ext.State.DelegationBug.