### PR TITLE
Added Apple Silicon to build instructions

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -53,6 +53,14 @@ pip install -r pyee/requirements.txt
 make
 ```
 
+**Mac M1 (Apple silicon)**
+
+```
+export ROCKSDB_PATH="$(echo) $(brew --prefix rocksdb)"
+export SNAPPY_PATH="$(echo) $(brew --prefix snappy)"
+CGO_CFLAGS=-I$ROCKSDB_PATH/include CGO_LDFLAGS="-L$ROCKSDB_PATH/lib -L$SNAPPY_PATH/lib" make
+```
+
 Output binaries are placed under `bin/` directory.
 
 


### PR DESCRIPTION
This pull request adds instructions to the build guide to make goloop on Apple silicon.