### PR TITLE
Add setNetworkScore has 2 params to `chainMethods`

### DIFF
--- a/icon/chainscore.go
+++ b/icon/chainscore.go
@@ -580,13 +580,22 @@ var chainMethods = []*chainMethod{
 	}, icmodule.RevisionEnableSetScoreOwner, 0},
 	{scoreapi.Method{
 		scoreapi.Function, "setNetworkScore",
+		scoreapi.FlagExternal, 2,
+		[]scoreapi.Parameter{
+			{"role", scoreapi.String, nil, nil},
+			{"address", scoreapi.Address, nil, nil},
+		},
+		nil,
+	}, icmodule.RevisionICON2R2, icmodule.RevisionICON2R2},
+	{scoreapi.Method{
+		scoreapi.Function, "setNetworkScore",
 		scoreapi.FlagExternal, 1,
 		[]scoreapi.Parameter{
 			{"role", scoreapi.String, nil, nil},
 			{"address", scoreapi.Address, nil, nil},
 		},
 		nil,
-	}, icmodule.RevisionICON2R2, 0},
+	}, icmodule.RevisionICON2R3, 0},
 	{scoreapi.Method{
 		scoreapi.Function, "getNetworkScores",
 		scoreapi.FlagExternal | scoreapi.FlagReadOnly, 0,

--- a/icon/chainscore_basic.go
+++ b/icon/chainscore_basic.go
@@ -307,9 +307,6 @@ func (s *chainScore) handleRevisionChange(as state.AccountState, r1, r2 int) err
 			if err := es.State.SetNonvotedPenaltySlashRatio(int(iconConfig.NonVotePenaltySlashRatio.Int64())); err != nil {
 				return err
 			}
-			if err := es.State.SetNetworkScore(icstate.GovernanceKey, govAddress); err != nil {
-				return err
-			}
 		}
 
 		// Enable ExtraMainPReps

--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -60,7 +60,7 @@ func (s *chainScore) checkNetworkScore(charge bool) error {
 	if err != nil {
 		return err
 	}
-	ns := es.State.GetNetworkScores()
+	ns := es.State.GetNetworkScores(s.newCallContext(s.cc))
 	for _, address := range ns {
 		if address.Equal(s.from) {
 			return nil
@@ -697,10 +697,10 @@ func (s *chainScore) Ex_getNetworkScores() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	ns := es.State.GetNetworkScores()
+	ns := es.State.GetNetworkScores(s.newCallContext(s.cc))
 	jso := make(map[string]interface{})
 	for k, v := range ns {
-		jso[k] = v.String()
+		jso[k] = v
 	}
 	return jso, nil
 }

--- a/icon/icmodule/context.go
+++ b/icon/icmodule/context.go
@@ -32,4 +32,5 @@ type CallContext interface {
 	SumOfStepUsed() *big.Int
 	OnEvent(addr module.Address, indexed, data [][]byte)
 	CallOnTimer(to module.Address, params []byte) error
+	Governance() module.Address
 }

--- a/icon/icsim/context.go
+++ b/icon/icsim/context.go
@@ -41,13 +41,13 @@ type WorldContext interface {
 
 type worldContext struct {
 	state.WorldState
-	blockHeight int64
+	blockHeight    int64
 	blockTimestamp int64
-	csi         module.ConsensusInfo
-	origin      module.Address
-	revision    module.Revision
-	stepPrice   *big.Int
-	txId        []byte
+	csi            module.ConsensusInfo
+	origin         module.Address
+	revision       module.Revision
+	stepPrice      *big.Int
+	txId           []byte
 }
 
 func (ctx *worldContext) addBalance(address module.Address, amount *big.Int) error {
@@ -63,7 +63,6 @@ func (ctx *worldContext) Revision() module.Revision {
 func (ctx *worldContext) BlockHeight() int64 {
 	return ctx.blockHeight
 }
-
 
 func (ctx *worldContext) Origin() module.Address {
 	return ctx.origin
@@ -205,12 +204,12 @@ func NewWorldContext(
 	csi module.ConsensusInfo, stepPrice *big.Int,
 ) WorldContext {
 	return &worldContext{
-		WorldState: ws,
-		blockHeight: blockHeight,
+		WorldState:     ws,
+		blockHeight:    blockHeight,
 		blockTimestamp: blockHeight * 2_000_000,
-		csi: csi,
-		revision: revision,
-		stepPrice: stepPrice,
+		csi:            csi,
+		revision:       revision,
+		stepPrice:      stepPrice,
 	}
 }
 
@@ -269,9 +268,13 @@ func (ctx *callContext) CallOnTimer(to module.Address, params []byte) error {
 	return nil
 }
 
+func (ctx *callContext) Governance() module.Address {
+	return ctx.Governance()
+}
+
 func NewCallContext(wc WorldContext, from module.Address) icmodule.CallContext {
 	return &callContext{
 		WorldContext: wc,
-		from: from,
+		from:         from,
 	}
 }

--- a/icon/iiss/context.go
+++ b/icon/iiss/context.go
@@ -90,7 +90,6 @@ func (ctx *worldContextImpl) addBalance(address module.Address, amount *big.Int)
 	return setBalance(address, as, new(big.Int).Add(ob, amount))
 }
 
-
 func (ctx *worldContextImpl) GetTotalSupply() *big.Int {
 	as := ctx.GetAccountState(state.SystemID)
 	tsVar := scoredb.NewVarDB(as, state.VarTotalSupply)
@@ -170,7 +169,7 @@ func NewWorldContext(ctx state.WorldContext) icmodule.WorldContext {
 
 type callContextImpl struct {
 	icmodule.WorldContext
-	cc contract.CallContext
+	cc   contract.CallContext
 	from module.Address
 }
 
@@ -244,10 +243,14 @@ func (ctx *callContextImpl) CallOnTimer(to module.Address, params []byte) error 
 	return nil
 }
 
+func (ctx *callContextImpl) Governance() module.Address {
+	return ctx.cc.Governance()
+}
+
 func NewCallContext(cc contract.CallContext, from module.Address) icmodule.CallContext {
 	return &callContextImpl{
 		WorldContext: NewWorldContext(cc),
-		cc: cc,
-		from: from,
+		cc:           cc,
+		from:         from,
 	}
 }

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -1719,7 +1719,7 @@ func (es *ExtensionStateImpl) transferRewardFund(cc icmodule.CallContext) error 
 		{icstate.CPSKey, rf.Icps},
 		{icstate.RelayKey, rf.Irelay},
 	}
-	ns := es.State.GetNetworkScores()
+	ns := es.State.GetNetworkScores(cc)
 	div := big.NewInt(100 * MonthBlock)
 	base := new(big.Int).Mul(rf.Iglobal, new(big.Int).SetInt64(term.Period()))
 	from := cc.Treasury()

--- a/icon/iiss/icstate/networkvalue.go
+++ b/icon/iiss/icstate/networkvalue.go
@@ -63,7 +63,7 @@ const (
 	GovernanceKey = "governance"
 )
 
-var AdditionalNetworkScoreKeys = [3]string{CPSKey, RelayKey}
+var AdditionalNetworkScoreKeys = []string{CPSKey, RelayKey}
 
 func getValue(store containerdb.ObjectStoreState, key string) containerdb.Value {
 	return containerdb.NewVarDB(

--- a/icon/iiss/icstate/networkvalue.go
+++ b/icon/iiss/icstate/networkvalue.go
@@ -17,8 +17,9 @@
 package icstate
 
 import (
-	"github.com/icon-project/goloop/service/scoreresult"
 	"math/big"
+
+	"github.com/icon-project/goloop/service/scoreresult"
 
 	"github.com/icon-project/goloop/module"
 
@@ -99,7 +100,7 @@ func (s *State) SetNetworkScore(role string, address module.Address) error {
 			return db.Set(role, address)
 		}
 	}
-	return icmodule.IllegalArgumentError.New("invalid Network SCORE role")
+	return icmodule.IllegalArgumentError.New("Invalid Network SCORE role")
 }
 
 func (s *State) GetNetworkScores(cc icmodule.CallContext) map[string]module.Address {


### PR DESCRIPTION
Add setNetworkScore has 2 params to `chainMethods`(for mainnet compatibility)

* Recognize governance SCORE as network SCORE even not specified with setNetworkScore.
* do not setNetworkScore(governance) on `handleRevisionChange`.