### PR TITLE
Clarify the default value for @Optional BigInteger

### DIFF
--- a/javaee/api/src/java/score/annotation/Optional.java
+++ b/javaee/api/src/java/score/annotation/Optional.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * If optional parameters were omitted when the external method is called, the value of optional parameters
  * would be their zero values.
  * The zero value is:
- *     0 for numeric types,
+ *     0 for numeric types (including BigInteger),
  *     false for the boolean type, and
  *     null for Object types.
  */


### PR DESCRIPTION
The `@Optional` documentation is unclear regarding the default value of an `@Optional BigInteger` value.

The BigInteger is both an Object and a numeric type.
A SCORE developer may assume it is an Object and compare it to null, whereas the SCORE engine set its value to 0 instead.