### PR TITLE
Refactor to use MissingTransactionInfo for rosetta APIs

### DIFF
--- a/server/v3/api_v3.go
+++ b/server/v3/api_v3.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -1348,7 +1349,7 @@ func findBlockAndTxInfoByRosettaTraceParam(
 	var err error
 
 	if len(param.Tx) > 0 {
-		if param.Tx[0:2] == "bx" {
+		if strings.HasPrefix(string(param.Tx), "bx") {
 			if blk, err = c.GetBlockByID(param.Tx.Bytes()); err != nil {
 				return nil, nil, jsonrpc.ErrorCodeNotFound.Wrap(err, c.debug)
 			}

--- a/server/v3/missingtxinfo.go
+++ b/server/v3/missingtxinfo.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package trace
+package v3
 
 var missingTxHashes = []string{
 	"\x3c\xf6\xc4\xde\x0e\x05\xd6\xcb\x95\x0d\x5c\x59\xd5\x1b\xad\xad\xa6\xa9\x67\x21\x94\x43\x72\xfa\x36\x8a\xe6\x6e\x91\xda\x2d\x8c",
@@ -53,14 +53,16 @@ var missingTxHashToSubTxHash = map[string]string{
 	missingTxHashes[4]: subTxHashes[4],
 }
 
-func GetMissingTxLocator(txHash []byte) (int64, int, bool) {
+type missingTransactions struct{}
+
+func (i missingTransactions) GetLocationOf(txHash []byte) (int64, int, bool) {
 	if loc, ok := missingTxLocators[string(txHash)]; ok {
 		return loc.height, loc.index, true
 	}
 	return -1, -1, false
 }
 
-func ReplaceMissingTxHash(height int64, txHash []byte) []byte {
+func (i missingTransactions) ReplaceID(height int64, txHash []byte) []byte {
 	if subTxHash, ok := missingTxHashToSubTxHash[string(txHash)]; ok {
 		if loc, ok := missingTxLocators[subTxHash]; ok {
 			if height == loc.height {
@@ -70,3 +72,6 @@ func ReplaceMissingTxHash(height int64, txHash []byte) []byte {
 	}
 	return txHash
 }
+
+// TransactionLocator object for accessing missed transaction information
+var iconMissedTransactions missingTransactions

--- a/server/v3/missingtxinfo_test.go
+++ b/server/v3/missingtxinfo_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package trace
+package v3
 
 import (
 	"testing"
@@ -24,14 +24,14 @@ import (
 
 func TestGetMissingTxLocator(t *testing.T) {
 	for _, txHash := range subTxHashes {
-		height, txIndex, ok := GetMissingTxLocator([]byte(txHash))
+		height, txIndex, ok := iconMissedTransactions.GetLocationOf([]byte(txHash))
 		assert.True(t, height > int64(0))
 		assert.True(t, txIndex >= 0)
 		assert.True(t, ok)
 	}
 
 	dummyTxHash := make([]byte, 32)
-	height, txIndex, ok := GetMissingTxLocator(dummyTxHash)
+	height, txIndex, ok := iconMissedTransactions.GetLocationOf(dummyTxHash)
 	assert.Equal(t, int64(-1), height)
 	assert.Equal(t, -1, txIndex)
 	assert.False(t, ok)
@@ -41,7 +41,7 @@ func TestReplaceMissingTxHash(t *testing.T) {
 	heights := []int64{43244423, 43271612, 43271612, 43292491, 43292491}
 
 	for i, txHash := range missingTxHashes {
-		subTxHash := string(ReplaceMissingTxHash(heights[i], []byte(txHash)))
+		subTxHash := string(iconMissedTransactions.ReplaceID(heights[i], []byte(txHash)))
 		assert.Equal(t, subTxHashes[i], subTxHash)
 		assert.Equal(t, subTxHash[31]+1, txHash[31])
 		assert.Equal(t, subTxHash[:31], txHash[:31])
@@ -50,13 +50,13 @@ func TestReplaceMissingTxHash(t *testing.T) {
 	// NoMissingTxHashes
 	height := int64(1234)
 	for _, noMissingTxHash := range subTxHashes {
-		txHash := string(ReplaceMissingTxHash(height, []byte(noMissingTxHash)))
+		txHash := string(iconMissedTransactions.ReplaceID(height, []byte(noMissingTxHash)))
 		assert.Equal(t, txHash, noMissingTxHash)
 	}
 
 	// MissingTxHash but height is different
 	for _, missingTxHash := range missingTxHashes {
-		txHash := string(ReplaceMissingTxHash(height, []byte(missingTxHash)))
+		txHash := string(iconMissedTransactions.ReplaceID(height, []byte(missingTxHash)))
 		assert.Equal(t, txHash, missingTxHash)
 	}
 }


### PR DESCRIPTION
Refactor to use MissingTransactionInfo object instead of using two global functions.