### PR TITLE
feat: publish docker image on push

### DIFF
--- a/.github/workflows/build_goloop_image.yml
+++ b/.github/workflows/build_goloop_image.yml
@@ -1,0 +1,42 @@
+name: Build and publish the gochain image
+
+'on':
+  push:
+    tags:
+      - '*'
+    branches:
+      - 'master'
+
+jobs:
+  build-goloop-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: goloop version
+        id: repository
+        run: echo  "::set-output name=tag::$(curl -s https://api.github.com/repos/icon-project/goloop/releases/latest|grep '"name"'|cut -d '"' -f4)"
+
+      - name: Clone goloop repository
+        run: git clone https://github.com/icon-project/goloop.git
+      
+      - name: Checkout the latest release version
+        run: git checkout ${{ steps.repository.outputs.tag }}
+        working-directory: goloop
+
+      - name: Log in to docker hub registry
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build gochain-image
+        run: make gochain-image
+        working-directory: goloop
+
+      - name: Push gochain-image to docker hub
+        run: |
+          docker push goloop/gochain-icon:latest
+        working-directory: goloop


### PR DESCRIPTION
Pushing to master builds and publishes the most recently released Goloop image to goloop/gochain-icon