### PR TITLE
Refactor getPRepStats and getPRepStatsOf APIs in ChainScore

### DIFF
--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -567,7 +567,7 @@ func (s *chainScore) Ex_getPRepStats() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return es.State.GetPRepStatsInJSON(rev, s.cc.BlockHeight())
+	return es.GetPRepStats(s.newCallContext(s.cc))
 }
 
 func (s *chainScore) Ex_getPRepStatsOf(address module.Address) (map[string]interface{}, error) {
@@ -581,7 +581,7 @@ func (s *chainScore) Ex_getPRepStatsOf(address module.Address) (map[string]inter
 	if err != nil {
 		return nil, err
 	}
-	return es.State.GetPRepStatsOfInJSON(s.cc.Revision().Value(), s.cc.BlockHeight(), address)
+	return es.GetPRepStatsOf(s.newCallContext(s.cc), address)
 }
 
 func (s *chainScore) Ex_disqualifyPRep(address module.Address) error {

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -1929,3 +1929,14 @@ func (es *ExtensionStateImpl) RequestUnjail(cc icmodule.CallContext) error {
 
 	return ps.NotifyEvent(NewStateContext(cc, es), icmodule.PRepEventRequestUnjail)
 }
+
+func (es *ExtensionStateImpl) GetPRepStats(cc icmodule.CallContext) (map[string]interface{}, error) {
+	sc := NewStateContext(cc, es)
+	return es.State.GetPRepStatsInJSON(sc)
+}
+
+func (es *ExtensionStateImpl) GetPRepStatsOf(
+	cc icmodule.CallContext, address module.Address) (map[string]interface{}, error) {
+	sc := NewStateContext(cc, es)
+	return es.State.GetPRepStatsOfInJSON(sc, address)
+}

--- a/icon/iiss/icstate/prepstatus.go
+++ b/icon/iiss/icstate/prepstatus.go
@@ -801,6 +801,14 @@ func (ps *PRepStatusState) DisableAs(status Status) (Grade, error) {
 	}
 }
 
+func (ps *PRepStatusState) ToJSON(sc icmodule.StateContext) map[string]interface{} {
+	jso := ps.prepStatusData.ToJSON(sc)
+	if sc.Revision() >= icmodule.RevisionUpdatePRepStats {
+		jso["owner"] = ps.owner
+	}
+	return jso
+}
+
 func newPRepStatusWithTag(_ icobject.Tag) *PRepStatusSnapshot {
 	return new(PRepStatusSnapshot)
 }
@@ -812,28 +820,4 @@ func NewPRepStatusWithSnapshot(owner module.Address, snapshot *PRepStatusSnapsho
 
 func NewPRepStatus(owner module.Address) *PRepStatusState {
 	return NewPRepStatusWithSnapshot(owner, emptyPRepStatusSnapshot)
-}
-
-type PRepStats struct {
-	owner module.Address
-	*PRepStatusState
-}
-
-func (p *PRepStats) Owner() module.Address {
-	return p.owner
-}
-
-func (p *PRepStats) ToJSON(rev int, blockHeight int64) map[string]interface{} {
-	jso := p.PRepStatusState.GetStatsInJSON(blockHeight)
-	if rev >= icmodule.RevisionUpdatePRepStats {
-		jso["owner"] = p.owner
-	}
-	return jso
-}
-
-func NewPRepStats(owner module.Address, ps *PRepStatusState) *PRepStats {
-	return &PRepStats{
-		owner:           owner,
-		PRepStatusState: ps,
-	}
 }

--- a/icon/iiss/icstate/prepstatus_test.go
+++ b/icon/iiss/icstate/prepstatus_test.go
@@ -841,11 +841,9 @@ func TestNewPRepStatus(t *testing.T) {
 	assert.True(t, ps.GetSnapshot().Equal(ps2.GetSnapshot()))
 }
 
-func TestPRepStats_ToJSON(t *testing.T) {
+func TestPRepStatusState_ToJSON(t *testing.T) {
 	ps := NewPRepStatus(newDummyAddress(1))
 	owner := newDummyAddress(1)
-
-	stats := NewPRepStats(owner, ps)
 
 	args := []struct {
 		rev int
@@ -857,8 +855,13 @@ func TestPRepStats_ToJSON(t *testing.T) {
 
 	for _, arg := range args {
 		name := fmt.Sprintf("rev-%02d", arg.rev)
+		sc := newMockStateContext(map[string]interface{}{
+			"blockHeight": int64(100),
+			"revision": arg.rev,
+		})
+
 		t.Run(name, func(t *testing.T) {
-			jso := stats.ToJSON(arg.rev, 100)
+			jso := ps.ToJSON(sc)
 			if arg.rev < icmodule.RevisionUpdatePRepStats {
 				_, ok := jso["owner"]
 				assert.False(t, ok)


### PR DESCRIPTION
* Remove useless PRepStats struct