### PR TITLE
Implement handleDoubleSignReport API in ChainScore

### DIFF
--- a/icon/chainscore.go
+++ b/icon/chainscore.go
@@ -815,6 +815,16 @@ var chainMethods = []*chainMethod{
 		nil,
 		nil,
 	}, icmodule.RevisionIISS4, 0},
+	{scoreapi.Method{
+		scoreapi.Function, contract.HandleDoubleSignReport,
+		scoreapi.FlagExternal, 3,
+		[]scoreapi.Parameter{
+			{"type", scoreapi.String, nil, nil},
+			{"blockHeight", scoreapi.Integer, nil, nil},
+			{"signer", scoreapi.Address, nil, nil},
+		},
+		nil,
+	}, icmodule.RevisionIISS4, 0},
 }
 
 func applyStepLimits(fee *FeeConfig, as state.AccountState) error {
@@ -1334,6 +1344,18 @@ func (s *chainScore) checkGovernance(charge bool) error {
 		return scoreresult.New(module.StatusAccessDenied, "NoPermission")
 	}
 	return nil
+}
+
+func (s *chainScore) checkSystem(charge bool) error {
+	if s.from != nil && s.from.Equal(state.SystemAddress) {
+		return nil
+	}
+	if charge {
+		if err := s.cc.ApplyCallSteps(); err != nil {
+			return err
+		}
+	}
+	return scoreresult.New(module.StatusAccessDenied, "NoPermission")
 }
 
 const (

--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -1010,9 +1010,6 @@ func (s *chainScore) Ex_handleDoubleSignReport(
 	if err != nil {
 		return err
 	}
-	if dsType != module.DSTProposal && dsType != module.DSTVote {
-		return scoreresult.InvalidParameterError.Errorf("UnknownDoubleSignType(%s)", dsType)
-	}
 	return es.HandleDoubleSignReport(
 		s.newCallContext(s.cc),
 		dsType,

--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -1011,7 +1011,7 @@ func (s *chainScore) Ex_handleDoubleSignReport(
 		return err
 	}
 	if dsType != module.DSTProposal && dsType != module.DSTVote {
-		return scoreresult.InvalidParameterError.Errorf("UnknownType(%s)", dsType)
+		return scoreresult.InvalidParameterError.Errorf("UnknownDoubleSignType(%s)", dsType)
 	}
 	return es.HandleDoubleSignReport(
 		s.newCallContext(s.cc),

--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -1000,3 +1000,23 @@ func (s *chainScore) Ex_requestUnjail() error {
 	}
 	return es.RequestUnjail(s.newCallContext(s.cc))
 }
+
+func (s *chainScore) Ex_handleDoubleSignReport(
+	dsType string, blockHeight *common.HexInt, signer module.Address) error {
+	if err := s.checkSystem(true); err != nil {
+		return err
+	}
+	es, err := s.getExtensionState()
+	if err != nil {
+		return err
+	}
+	if dsType != module.DSTProposal && dsType != module.DSTVote {
+		return scoreresult.InvalidParameterError.Errorf("UnknownType(%s)", dsType)
+	}
+	return es.HandleDoubleSignReport(
+		s.newCallContext(s.cc),
+		dsType,
+		blockHeight.Int64(),
+		signer,
+	)
+}

--- a/icon/icmodule/constant.go
+++ b/icon/icmodule/constant.go
@@ -82,7 +82,7 @@ const (
 	DefaultContinuousBlockValidationSlashingRate  = Rate(1)           // 0.01%
 	DefaultBlockValidationSlashingRate            = Rate(0)           // 0%
 	DefaultMissingNetworkProposalVoteSlashingRate = Rate(1)           // 0.01%
-	DefaultDoubleVoteSlashingRate                 = Rate(1000)        // 10%
+	DefaultDoubleSignSlashingRate                 = Rate(1000)        // 10%
 )
 
 // The following variables are read-only

--- a/icon/icmodule/errors_test.go
+++ b/icon/icmodule/errors_test.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 ICON Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package icmodule
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/icon-project/goloop/common/errors"
+	"github.com/icon-project/goloop/service/scoreresult"
+)
+
+func TestErrors(t *testing.T) {
+	args := []errors.Code{
+		IllegalArgumentError,
+		DuplicateError,
+		InvalidStateError,
+		NotFoundError,
+		NotReadyError,
+	}
+	for i, arg := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, scoreresult.RevertedError+errors.Code(i), arg)
+		})
+	}
+}

--- a/icon/icmodule/penalty.go
+++ b/icon/icmodule/penalty.go
@@ -24,7 +24,7 @@ const (
 	PenaltyAccumulatedValidationFailure
 	PenaltyValidationFailure
 	PenaltyMissedNetworkProposalVote
-	PenaltyDoubleVote
+	PenaltyDoubleSign
 	PenaltyReserved
 )
 
@@ -34,7 +34,7 @@ var penaltyNames = []string{
 	"accumulatedValidationFailure",
 	"validationFailure",
 	"missedNetworkProposalVote",
-	"doubleVote",
+	"doubleSign",
 }
 
 var penaltyTypes = []PenaltyType {
@@ -42,7 +42,7 @@ var penaltyTypes = []PenaltyType {
 	PenaltyAccumulatedValidationFailure,
 	PenaltyValidationFailure,
 	PenaltyMissedNetworkProposalVote,
-	PenaltyDoubleVote,
+	PenaltyDoubleSign,
 }
 
 func (p PenaltyType) String() string {

--- a/icon/icmodule/penalty_test.go
+++ b/icon/icmodule/penalty_test.go
@@ -39,7 +39,7 @@ func TestToPenaltyType(t *testing.T) {
 		{"accumulatedValidationFailure", PenaltyAccumulatedValidationFailure},
 		{"validationFailure", PenaltyValidationFailure},
 		{"missedNetworkProposalVote", PenaltyMissedNetworkProposalVote},
-		{"doubleVote", PenaltyDoubleVote},
+		{"doubleSign", PenaltyDoubleSign},
 		{"", PenaltyNone},
 		{"invalid_name", PenaltyNone},
 	}
@@ -61,7 +61,7 @@ func TestPenaltyType_String(t *testing.T) {
 		{PenaltyAccumulatedValidationFailure, "accumulatedValidationFailure"},
 		{PenaltyValidationFailure, "validationFailure"},
 		{PenaltyMissedNetworkProposalVote, "missedNetworkProposalVote"},
-		{PenaltyDoubleVote, "doubleVote"},
+		{PenaltyDoubleSign, "doubleSign"},
 		{PenaltyNone, ""},
 	}
 	for i, arg := range args {

--- a/icon/icmodule/revision.go
+++ b/icon/icmodule/revision.go
@@ -165,7 +165,7 @@ var revisionFlags = []module.Revision{
 	// Revision23
 	0,
 	// Revision24
-	0,
+	module.ReportDoubleSign,
 }
 
 func init() {

--- a/icon/icsim/config.go
+++ b/icon/icsim/config.go
@@ -21,19 +21,23 @@ type SimConfig struct {
 	ExtraMainPRepCount                   int64
 	Irep                                 int64
 	Rrep                                 int64
-	BondRequirement                      icmodule.Rate
 	UnbondingPeriodMultiplier            int64
 	UnstakeSlotMax                       int64
 	LockMinMultiplier                    int64
 	LockMaxMultiplier                    int64
 	UnbondingMax                         int64
 	ValidationPenaltyCondition           int64
+	DelegationSlotMax                    int64
 	ConsistentValidationPenaltyCondition int64
 	ConsistentValidationPenaltyMask      int64
 	ConsistentValidationPenaltySlashRate icmodule.Rate
 	NonVotePenaltySlashRate              icmodule.Rate
-	DelegationSlotMax                    int64
+	BondRequirement                      icmodule.Rate
 	RewardFund
+}
+
+func (cfg *SimConfig) TotalMainPRepCount() int64 {
+	return cfg.MainPRepCount + cfg.ExtraMainPRepCount
 }
 
 func NewSimConfig() *SimConfig {

--- a/icon/icsim/doublesign_test.go
+++ b/icon/icsim/doublesign_test.go
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2023 ICON Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package icsim
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/icon-project/goloop/icon/icmodule"
+	"github.com/icon-project/goloop/icon/iiss/icstate"
+	"github.com/icon-project/goloop/icon/iiss/icutils"
+	"github.com/icon-project/goloop/module"
+	"github.com/icon-project/goloop/service/state"
+)
+
+func TestDoubleSign_RequestUnjailNormalCase(t *testing.T) {
+	const (
+		termPeriod = int64(10)
+	)
+	var err error
+	var dsBlockHeight int64
+	var csi module.ConsensusInfo
+	var rcpt Receipt
+
+	cfg := NewSimConfigWithParams(map[string]interface{}{
+		"TermPeriod": termPeriod,
+	})
+	env, err := NewEnv(cfg, icmodule.RevisionIISS4)
+	sim := env.Simulator()
+	assert.NoError(t, err)
+	assert.NotNil(t, sim)
+	assert.Equal(t, sim.Revision(), icmodule.ValueToRevision(icmodule.RevisionIISS4))
+
+	// T(0)
+	assert.NoError(t, sim.GoToTermEnd(nil))
+	term := sim.TermSnapshot()
+	assert.Equal(t, icstate.IISSVersion4, term.GetIISSVersion())
+
+	// Next Term
+
+	prep0 := env.preps[0]
+	prep0Sub := env.preps[cfg.TotalMainPRepCount()]
+	prep := sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeMain, prep.Grade())
+	assert.Zero(t, prep.JailFlags())
+
+	// T(1) : SuccessCase(HandleDoubleSignReport)
+	dsType := module.DSTProposal
+	dsBlockHeight = sim.BlockHeight() - 10
+	rcpt, err = sim.GoByHandleDoubleSignReport(csi, state.SystemAddress, dsType, dsBlockHeight, prep0)
+	assert.NoError(t, err)
+	assert.True(t, CheckReceiptSuccess(rcpt))
+	// Check the status of prep0
+	prep = sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
+	assert.True(t, icutils.MatchAll(prep.JailFlags(), icstate.JFlagInJail|icstate.JFlagDoubleSign))
+	assert.Zero(t, prep.MinDoubleSignHeight())
+	// Check the status of prep0Sub(prep25)
+	prep = sim.GetPRep(prep0Sub)
+	assert.Equal(t, icstate.GradeMain, prep.Grade())
+
+	// Move to the block which is 5 blocks earlier
+	term = sim.TermSnapshot()
+	assert.NoError(t, sim.GoTo(csi, term.GetEndHeight()-5))
+
+	// T(100 - 5) : DoubleSignReport for the PRep with JailFlagDoubleSign is ignored silently (Success)
+	rcpt, err = sim.GoByHandleDoubleSignReport(csi, state.SystemAddress, module.DSTVote, dsBlockHeight+1, prep0)
+	assert.NoError(t, err)
+	assert.True(t, rcpt.Status() == 1)
+
+	// T(100 - 5 + 1)
+	assert.NoError(t, sim.GoToTermEnd(csi))
+
+	// Next Term
+
+	// T(0) : RequestUnjail transaction
+	prep = sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
+	rcpt, err = sim.GoByRequestUnjail(csi, prep0)
+	assert.NoError(t, err)
+	assert.True(t, CheckReceiptSuccess(rcpt))
+	prep = sim.GetPRep(prep0)
+	assert.True(t, icutils.MatchAll(
+		prep.JailFlags(), icstate.JFlagUnjailing|icstate.JFlagDoubleSign|icstate.JFlagInJail))
+	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
+	assert.True(t, prep.IsJailInfoElectable())
+
+	// T(2) : Go to term end
+	assert.NoError(t, sim.GoToTermEnd(nil))
+	prep = sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeMain, prep.Grade())
+	assert.Zero(t, prep.JailFlags())
+	assert.Equal(t, sim.BlockHeight(), prep.MinDoubleSignHeight())
+	vl := sim.ValidatorList()
+	assert.True(t, vl[0].Address().Equal(prep0))
+}
+
+func TestHandleDoubleSignReport_Slashing(t *testing.T) {
+	const (
+		termPeriod = int64(10)
+	)
+	var err error
+	var dsBlockHeight int64
+	var csi module.ConsensusInfo
+	var rcpt Receipt
+	var revision module.Revision
+	slashingRate := icmodule.ToRate(10)
+
+	cfg := NewSimConfigWithParams(map[string]interface{}{
+		"TermPeriod": termPeriod,
+	})
+	revision = icmodule.ValueToRevision(icmodule.RevisionPreIISS4)
+	env, err := NewEnv(cfg, revision)
+	sim := env.Simulator()
+	assert.NoError(t, err)
+	assert.NotNil(t, sim)
+	assert.Equal(t, revision, sim.Revision())
+
+	// Term
+	// T(0)
+	term := sim.TermSnapshot()
+	assert.Equal(t, icstate.IISSVersion3, term.GetIISSVersion())
+	revision = icmodule.ValueToRevision(icmodule.RevisionIISS4)
+	rcpt, err = sim.GoBySetRevision(csi, env.Governance(), revision)
+	assert.NoError(t, err)
+	assert.True(t, CheckReceiptSuccess(rcpt))
+
+	// T(1)
+	const penaltyType = icmodule.PenaltyDoubleSign
+	rcpt, err = sim.GoBySetSlashingRates(csi, env.Governance(), map[string]icmodule.Rate{
+		penaltyType.String(): slashingRate,
+	})
+	assert.NoError(t, err)
+	assert.True(t, CheckReceiptSuccess(rcpt))
+	jso, err := sim.GetSlashingRates([]icmodule.PenaltyType{icmodule.PenaltyDoubleSign})
+	assert.NoError(t, err)
+	assert.Equal(t, slashingRate.NumInt64(), jso[penaltyType.String()])
+
+	assert.NoError(t, sim.GoToTermEnd(nil))
+
+	// Next Term
+	// T(0)
+	term = sim.TermSnapshot()
+	assert.Equal(t, icstate.IISSVersion4, term.GetIISSVersion())
+
+	prep0 := env.preps[0]
+	prep0Sub := env.preps[cfg.TotalMainPRepCount()]
+	prep := sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeMain, prep.Grade())
+	assert.Zero(t, prep.JailFlags())
+
+	// T(1) : SuccessCase(HandleDoubleSignReport)
+	prep = sim.GetPRep(prep0)
+	oldBonded := prep.Bonded()
+	oldTotalSupply := sim.TotalSupply()
+	oldTotalStake := sim.TotalStake()
+
+	dsType := module.DSTProposal
+	dsBlockHeight = sim.BlockHeight() - 10
+	rcpt, err = sim.GoByHandleDoubleSignReport(csi, state.SystemAddress, dsType, dsBlockHeight, prep0)
+	assert.NoError(t, err)
+	assert.True(t, CheckReceiptSuccess(rcpt))
+	// Check the status of prep0
+	prep = sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
+	assert.True(t, icutils.MatchAll(prep.JailFlags(), icstate.JFlagInJail|icstate.JFlagDoubleSign))
+	assert.Zero(t, prep.MinDoubleSignHeight())
+	// Check the status of prep0Sub(prep25)
+	prep = sim.GetPRep(prep0Sub)
+	assert.Equal(t, icstate.GradeMain, prep.Grade())
+	// Slashing for DoubleSignPenalty
+	prep = sim.GetPRep(prep0)
+	newBonded := prep.Bonded()
+	slashed := estimateSlashed(slashingRate, oldBonded)
+	assert.Zero(t, newBonded.Cmp(new(big.Int).Sub(oldBonded, slashed)))
+	// Check if the slashed amount is burned
+	assert.Zero(t, sim.TotalSupply().Cmp(new(big.Int).Sub(oldTotalSupply, slashed)))
+	assert.Zero(t, sim.TotalStake().Cmp(new(big.Int).Sub(oldTotalStake, slashed)))
+	bonderAccount := sim.GetAccountSnapshot(env.bonders[0])
+	assert.Zero(t, newBonded.Cmp(bonderAccount.Bond()))
+}
+
+func TestDoubleSign_HandleDoubleSignReportErrorCases(t *testing.T) {
+	const (
+		termPeriod = int64(10)
+	)
+	var err error
+	var csi module.ConsensusInfo
+	var rcpt Receipt
+
+	cfg := NewSimConfigWithParams(map[string]interface{}{
+		"TermPeriod": termPeriod,
+	})
+	env, err := NewEnv(cfg, icmodule.RevisionIISS4)
+	sim := env.Simulator()
+	assert.NoError(t, err)
+	assert.NotNil(t, sim)
+	assert.Equal(t, sim.Revision(), icmodule.ValueToRevision(icmodule.RevisionIISS4))
+
+	// T(0)
+	assert.NoError(t, sim.GoToTermEnd(nil))
+	term := sim.TermSnapshot()
+	assert.Equal(t, icstate.IISSVersion4, term.GetIISSVersion())
+
+	// Next Term
+	prep0 := env.preps[0]
+	dsBlockHeight := sim.BlockHeight() - 10
+
+	// T(0) : ErrorCases of HandleDoubleSignReport
+	args := []struct {
+		dsType        string
+		dsBlockHeight int64
+		signer        module.Address
+	}{
+		{"InvalidType", dsBlockHeight, prep0},
+		{module.DSTProposal, int64(-1), prep0},
+		{module.DSTVote, int64(0), prep0},
+		{module.DSTProposal, int64(-2), prep0},
+		{module.DSTVote, int64(-3), prep0},
+		{module.DSTProposal, sim.BlockHeight() - 10, env.users[99]},
+		{module.DSTVote, sim.BlockHeight() - 10, env.users[99]},
+	}
+	for i, arg := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			dsBlockHeight = arg.dsBlockHeight
+			switch dsBlockHeight {
+			case -2:
+				dsBlockHeight = sim.BlockHeight() + 1
+			case -3:
+				dsBlockHeight = sim.BlockHeight() + 2
+			}
+
+			// ErrorCase(InvalidDoubleSignBlockHeight)
+			rcpt, err = sim.GoByHandleDoubleSignReport(
+				csi, state.SystemAddress, arg.dsType, dsBlockHeight, arg.signer)
+			assert.NoError(t, err)
+			assert.True(t, rcpt.Status() == 0)
+
+			// No impact on PRep's JailFlags
+			prep := sim.GetPRep(prep0)
+			assert.Zero(t, prep.JailFlags())
+			assert.Equal(t, icstate.GradeMain, prep.Grade())
+			assert.Zero(t, prep.MinDoubleSignHeight())
+		})
+	}
+}
+
+func TestDoubleSign_RequestUnjailForNormalPRep(t *testing.T) {
+	const (
+		termPeriod = int64(10)
+	)
+	var err error
+	var csi module.ConsensusInfo
+	var rcpt Receipt
+
+	cfg := NewSimConfigWithParams(map[string]interface{}{
+		"TermPeriod": termPeriod,
+	})
+	env, err := NewEnv(cfg, icmodule.RevisionIISS4)
+	sim := env.Simulator()
+	assert.NoError(t, err)
+	assert.NotNil(t, sim)
+	assert.Equal(t, sim.Revision(), icmodule.ValueToRevision(icmodule.RevisionIISS4))
+
+	// T(0)
+	assert.NoError(t, sim.GoToTermEnd(nil))
+	term := sim.TermSnapshot()
+	assert.Equal(t, icstate.IISSVersion4, term.GetIISSVersion())
+
+	// Next Term
+
+	// T(0)
+	prep0 := env.preps[0]
+	prep := sim.GetPRep(prep0)
+	assert.Equal(t, icstate.GradeMain, prep.Grade())
+	assert.Zero(t, prep.JailFlags())
+
+	// UnjailRequest for a normal PRep will cause transaction failure
+	rcpt, err = sim.GoByRequestUnjail(csi, prep0)
+	assert.NoError(t, err)
+	assert.Zero(t, rcpt.Status())
+	assert.Zero(t, sim.GetPRep(prep0).JailFlags())
+}

--- a/icon/icsim/simulator.go
+++ b/icon/icsim/simulator.go
@@ -88,6 +88,7 @@ type Simulator interface {
 	GetStateContext() icmodule.StateContext
 	TermSnapshot() *icstate.TermSnapshot
 	GetPReps(grade icstate.Grade) []*icstate.PRep
+	GetAccountSnapshot(address module.Address) *icstate.AccountSnapshot
 
 	NewDefaultConsensusInfo() module.ConsensusInfo
 	NewConsensusInfo(voted []bool) (module.ConsensusInfo, error)

--- a/icon/icsim/simulator.go
+++ b/icon/icsim/simulator.go
@@ -45,6 +45,7 @@ const (
 	TypeInitCommissionRate
 	TypeSetCommissionRate
 	TypeRequestUnjail
+	TypeHandleDoubleSignReport
 )
 
 type Transaction interface {
@@ -164,6 +165,9 @@ type Simulator interface {
 	SetCommissionRate(from module.Address, rate icmodule.Rate) Transaction
 	GoBySetCommissionRate(csi module.ConsensusInfo, from module.Address, rate icmodule.Rate) (Receipt, error)
 
+	HandleDoubleSignReport(from module.Address, dsType string, dsBlockHeight int64, signer module.Address) Transaction
+	GoByHandleDoubleSignReport(csi module.ConsensusInfo,
+		from module.Address, dsType string, dsBlockHeight int64, signer module.Address) (Receipt, error)
 	RequestUnjail(from module.Address) Transaction
 	GoByRequestUnjail(csi module.ConsensusInfo, from module.Address) (Receipt, error)
 }

--- a/icon/icsim/simulatorimpl.go
+++ b/icon/icsim/simulatorimpl.go
@@ -140,7 +140,7 @@ func (sim *simulatorImpl) init(
 	}
 
 	// Initialize revision
-	rev := icutils.Min(revision.Value(), icmodule.Revision13)
+	rev := icutils.Min(revision.Value(), icmodule.Revision12)
 	if err = sim.handleRevisionChange(ws, 0, rev); err != nil {
 		return err
 	}
@@ -699,6 +699,11 @@ func (sim *simulatorImpl) ValidatorList() []module.Validator {
 		vl[i] = v
 	}
 	return vl
+}
+
+func (sim *simulatorImpl) GetAccountSnapshot(address module.Address) *icstate.AccountSnapshot {
+	es := sim.getExtensionState(true)
+	return es.State.GetAccountSnapshot(address)
 }
 
 func (sim *simulatorImpl) GetStateContext() icmodule.StateContext {

--- a/icon/icsim/simulatorimpl.go
+++ b/icon/icsim/simulatorimpl.go
@@ -430,6 +430,8 @@ func (sim *simulatorImpl) executeTx(wc WorldContext, tx Transaction) error {
 		err = sim.setCommissionRate(es, wc, tx)
 	case TypeRequestUnjail:
 		err = sim.requestUnjail(es, wc, tx)
+	case TypeHandleDoubleSignReport:
+		err = sim.handleDoubleSignReport(es, wc, tx)
 	default:
 		return errors.Errorf("Unexpected transaction: %v", tx.Type())
 	}
@@ -805,6 +807,26 @@ func (sim *simulatorImpl) requestUnjail(es *iiss.ExtensionStateImpl, wc WorldCon
 	from := args[0].(module.Address)
 	cc := NewCallContext(wc, from)
 	return es.RequestUnjail(cc)
+}
+
+func (sim *simulatorImpl) HandleDoubleSignReport(
+	from module.Address, dsType string, dsBlockHeight int64, signer module.Address) Transaction {
+	return NewTransaction(TypeHandleDoubleSignReport, from, dsType, dsBlockHeight, signer)
+}
+
+func (sim *simulatorImpl) GoByHandleDoubleSignReport(csi module.ConsensusInfo,
+	from module.Address, dsType string, dsBlockHeight int64, signer module.Address) (Receipt, error) {
+	return sim.goByOneTransaction(csi, TypeHandleDoubleSignReport, from, dsType, dsBlockHeight, signer)
+}
+
+func (sim *simulatorImpl) handleDoubleSignReport(es *iiss.ExtensionStateImpl, wc WorldContext, tx Transaction) error {
+	args := tx.Args()
+	from := args[0].(module.Address)
+	dsType := args[1].(string)
+	dsBlockHeight := args[2].(int64)
+	signer := args[3].(module.Address)
+	cc := NewCallContext(wc, from)
+	return es.HandleDoubleSignReport(cc, dsType, dsBlockHeight, signer)
 }
 
 func NewSimulator(

--- a/icon/iiss/eventlog.go
+++ b/icon/iiss/eventlog.go
@@ -281,3 +281,10 @@ func recordICXBurnedEvent(cc icmodule.CallContext, from module.Address, amount, 
 		)
 	}
 }
+
+func recordDoubleSignReportedEvent(cc icmodule.CallContext, signer module.Address, dsBlockHeight int64, dsType string) {
+	cc.OnEvent(state.SystemAddress,
+		[][]byte{[]byte("DoubleSignReported(Address,int,str)"), signer.Bytes()},
+		[][]byte{intconv.Int64ToBytes(dsBlockHeight), []byte(dsType)},
+	)
+}

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -1951,7 +1951,7 @@ func (es *ExtensionStateImpl) HandleDoubleSignReport(
 		return nil
 	}
 
-	const pt = icmodule.PenaltyDoubleVote
+	const pt = icmodule.PenaltyDoubleSign
 	if err := ps.NotifyEvent(sc, icmodule.PRepEventImposePenalty, pt); err != nil {
 		return err
 	}

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -1950,7 +1950,9 @@ func (es *ExtensionStateImpl) HandleDoubleSignReport(
 
 	sc := NewStateContext(cc, es)
 	if sc.TermIISSVersion() < icstate.IISSVersion4 {
-		return icmodule.NotReadyError.New("IISS4NotReady")
+		// Ignore DoubleSignReports silently
+		//return icmodule.NotReadyError.New("IISS4NotReady")
+		return nil
 	}
 
 	owner := es.State.GetOwnerByNode(signer)

--- a/icon/iiss/extension_test.go
+++ b/icon/iiss/extension_test.go
@@ -509,7 +509,7 @@ func TestExtensionStateImpl_SetSlashingRates(t *testing.T) {
 				icmodule.PenaltyValidationFailure.String():            icmodule.ToRate(0),
 				icmodule.PenaltyAccumulatedValidationFailure.String(): icmodule.ToRate(20),
 				icmodule.PenaltyPRepDisqualification.String():         icmodule.ToRate(100),
-				icmodule.PenaltyDoubleVote.String():                   icmodule.ToRate(10),
+				icmodule.PenaltyDoubleSign.String():                   icmodule.ToRate(10),
 				icmodule.PenaltyMissedNetworkProposalVote.String():    icmodule.ToRate(7),
 			},
 			true,
@@ -519,7 +519,7 @@ func TestExtensionStateImpl_SetSlashingRates(t *testing.T) {
 				icmodule.PenaltyValidationFailure.String():            icmodule.ToRate(0),
 				icmodule.PenaltyAccumulatedValidationFailure.String(): icmodule.ToRate(20),
 				icmodule.PenaltyPRepDisqualification.String():         icmodule.ToRate(100),
-				icmodule.PenaltyDoubleVote.String():                   icmodule.ToRate(-10),
+				icmodule.PenaltyDoubleSign.String():                   icmodule.ToRate(-10),
 				icmodule.PenaltyMissedNetworkProposalVote.String():    icmodule.ToRate(7),
 			},
 			false,
@@ -563,7 +563,7 @@ func TestExtensionStateImpl_SetSlashingRates(t *testing.T) {
 	}
 
 	penaltyTypes := []icmodule.PenaltyType{
-		icmodule.PenaltyDoubleVote,
+		icmodule.PenaltyDoubleSign,
 		icmodule.PenaltyAccumulatedValidationFailure,
 	}
 	jso, err = es.GetSlashingRates(cc, penaltyTypes)

--- a/icon/iiss/icstate/prep_test.go
+++ b/icon/iiss/icstate/prep_test.go
@@ -142,7 +142,7 @@ func TestPRep_ToJSON(t *testing.T) {
 	assert.Equal(t, prep.HasPubKey(sc.GetActiveDSAMask()), jso["hasPublicKey"].(bool))
 	assert.Equal(t, prep.JailFlags(), jso["jailFlags"].(int))
 	assert.Equal(t, prep.UnjailRequestHeight(), jso["unjailRequestHeight"].(int64))
-	assert.Equal(t, prep.MinDoubleVoteHeight(), jso["minDoubleVoteHeight"].(int64))
+	assert.Equal(t, prep.MinDoubleSignHeight(), jso["minDoubleSignHeight"].(int64))
 }
 
 func TestPRep_IsElectable(t *testing.T) {
@@ -170,7 +170,7 @@ func TestPRep_IsElectable(t *testing.T) {
 		{Active, big.NewInt(100), int64(3), icmodule.PenaltyNone, true},
 		{Active, big.NewInt(100), int64(3), icmodule.PenaltyAccumulatedValidationFailure, false},
 		{Active, big.NewInt(100), int64(3), icmodule.PenaltyValidationFailure, false},
-		{Active, big.NewInt(100), int64(3), icmodule.PenaltyDoubleVote, false},
+		{Active, big.NewInt(100), int64(3), icmodule.PenaltyDoubleSign, false},
 		{Unregistered, big.NewInt(100), int64(3), icmodule.PenaltyNone, false},
 		{Disqualified, big.NewInt(100), int64(3), icmodule.PenaltyNone, false},
 	}

--- a/icon/iiss/icstate/prepstatus.go
+++ b/icon/iiss/icstate/prepstatus.go
@@ -336,8 +336,8 @@ func (ps *prepStatusData) getPenaltyTypeV1() int {
 	if icutils.MatchAll(ps.ji.Flags(), JFlagAccumulatedValidationFailure) {
 		ptBits |= 1 << icmodule.PenaltyAccumulatedValidationFailure
 	}
-	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleVote) {
-		ptBits |= 1 << icmodule.PenaltyDoubleVote
+	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleSign) {
+		ptBits |= 1 << icmodule.PenaltyDoubleSign
 	}
 	return ptBits
 }
@@ -450,8 +450,8 @@ func (ps *prepStatusData) UnjailRequestHeight() int64 {
 	return ps.ji.UnjailRequestHeight()
 }
 
-func (ps *prepStatusData) MinDoubleVoteHeight() int64 {
-	return ps.ji.MinDoubleVoteHeight()
+func (ps *prepStatusData) MinDoubleSignHeight() int64 {
+	return ps.ji.MinDoubleSignHeight()
 }
 
 type PRepStatusSnapshot struct {
@@ -727,7 +727,7 @@ func (ps *PRepStatusState) onValidatorOut(sc icmodule.StateContext) error {
 func (ps *PRepStatusState) onPenaltyImposed(sc icmodule.StateContext, pt icmodule.PenaltyType) error {
 	if pt != icmodule.PenaltyValidationFailure &&
 		pt != icmodule.PenaltyAccumulatedValidationFailure &&
-		pt != icmodule.PenaltyDoubleVote {
+		pt != icmodule.PenaltyDoubleSign {
 		return nil
 	}
 
@@ -752,11 +752,11 @@ func (ps *PRepStatusState) IsDoubleSignReportApplicable(sc icmodule.StateContext
 	if !ps.IsActive() {
 		return false
 	}
-	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleVote|JFlagInJail) {
+	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleSign|JFlagInJail) {
 		// Already in Jail due to DoubleSignReport
 		return false
 	}
-	if dsBlockHeight <= ps.ji.MinDoubleVoteHeight() {
+	if dsBlockHeight <= ps.ji.MinDoubleSignHeight() {
 		// DoubleSignReport is too old to accept
 		return false
 	}

--- a/icon/iiss/icstate/prepstatus.go
+++ b/icon/iiss/icstate/prepstatus.go
@@ -739,12 +739,28 @@ func (ps *PRepStatusState) onPenaltyImposed(sc icmodule.StateContext, pt icmodul
 		ps.vFailCont = 0
 		ps.vPenaltyMask |= 1
 	}
+
 	if err := ps.ji.OnPenaltyImposed(sc, pt); err != nil {
 		return err
 	}
 	ps.grade = GradeCandidate
 	ps.setDirty()
 	return nil
+}
+
+func (ps *PRepStatusState) IsDoubleSignReportApplicable(sc icmodule.StateContext, dsBlockHeight int64) bool {
+	if !ps.IsActive() {
+		return false
+	}
+	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleVote|JFlagInJail) {
+		// Already in Jail due to DoubleSignReport
+		return false
+	}
+	if dsBlockHeight <= ps.ji.MinDoubleVoteHeight() {
+		// DoubleSignReport is too old to accept
+		return false
+	}
+	return true
 }
 
 func (ps *PRepStatusState) onTermEnd(sc icmodule.StateContext, newGrade Grade, limit int) error {

--- a/icon/iiss/icstate/prepstatus.go
+++ b/icon/iiss/icstate/prepstatus.go
@@ -454,6 +454,21 @@ func (ps *prepStatusData) MinDoubleSignHeight() int64 {
 	return ps.ji.MinDoubleSignHeight()
 }
 
+func (ps *prepStatusData) IsDoubleSignReportable(sc icmodule.StateContext, dsBlockHeight int64) bool {
+	if !ps.IsActive() {
+		return false
+	}
+	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleSign) {
+		// Already in Jail due to DoubleSignReport
+		return false
+	}
+	if dsBlockHeight <= ps.ji.MinDoubleSignHeight() {
+		// DoubleSignReport is too old to accept
+		return false
+	}
+	return true
+}
+
 type PRepStatusSnapshot struct {
 	icobject.NoDatabase
 	prepStatusData
@@ -746,21 +761,6 @@ func (ps *PRepStatusState) onPenaltyImposed(sc icmodule.StateContext, pt icmodul
 	ps.grade = GradeCandidate
 	ps.setDirty()
 	return nil
-}
-
-func (ps *PRepStatusState) IsDoubleSignReportApplicable(sc icmodule.StateContext, dsBlockHeight int64) bool {
-	if !ps.IsActive() {
-		return false
-	}
-	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleSign|JFlagInJail) {
-		// Already in Jail due to DoubleSignReport
-		return false
-	}
-	if dsBlockHeight <= ps.ji.MinDoubleSignHeight() {
-		// DoubleSignReport is too old to accept
-		return false
-	}
-	return true
 }
 
 func (ps *PRepStatusState) onTermEnd(sc icmodule.StateContext, newGrade Grade, limit int) error {

--- a/icon/iiss/icstate/prepstatus_test.go
+++ b/icon/iiss/icstate/prepstatus_test.go
@@ -699,16 +699,16 @@ func TestPRepStatusSnapshot_RLPEncodeFields(t *testing.T) {
 		dsaMask             int64
 		jailFlags           int
 		unjailRequestHeight int64
-		minDoubleVoteHeight int64
+		minDoubleSignHeight int64
 	}{
 		{0, 0, 0, 0},
 		{1, 0, 0, 0},
 		{0, JFlagInJail, 0, 0},
 		{0, JFlagInJail | JFlagUnjailing, 100, 0},
-		{0, JFlagInJail | JFlagDoubleVote, 0, 0},
+		{0, JFlagInJail | JFlagDoubleSign, 0, 0},
 		{0, 0, 0, 0},
 		{0, 0, 0, 200},
-		{1, JFlagInJail | JFlagUnjailing | JFlagDoubleVote, 100, 200},
+		{1, JFlagInJail | JFlagUnjailing | JFlagDoubleSign, 100, 200},
 	}
 
 	for i, arg := range args {
@@ -716,12 +716,12 @@ func TestPRepStatusSnapshot_RLPEncodeFields(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			state := NewPRepStatus(newDummyAddress(i + 1))
 			state.dsaMask = arg.dsaMask
-			state.ji = *newJailInfo(arg.jailFlags, arg.unjailRequestHeight, arg.minDoubleVoteHeight)
+			state.ji = *newJailInfo(arg.jailFlags, arg.unjailRequestHeight, arg.minDoubleSignHeight)
 			state.setDirty()
 
 			snapshot0 := state.GetSnapshot()
 			assert.Equal(t, arg.unjailRequestHeight, snapshot0.UnjailRequestHeight())
-			assert.Equal(t, arg.minDoubleVoteHeight, snapshot0.MinDoubleVoteHeight())
+			assert.Equal(t, arg.minDoubleSignHeight, snapshot0.MinDoubleSignHeight())
 
 			buf := bytes.NewBuffer(nil)
 			e := codec.BC.NewEncoder(buf)
@@ -940,7 +940,7 @@ func TestPRepStatusState_NotifyEvent(t *testing.T) {
 	assert.True(t, ps.IsUnjailable())
 	assert.False(t, ps.IsJailInfoElectable())
 	assert.Zero(t, ps.UnjailRequestHeight())
-	assert.Zero(t, ps.MinDoubleVoteHeight())
+	assert.Zero(t, ps.MinDoubleSignHeight())
 	assert.Equal(t, JFlagInJail, ps.JailFlags())
 
 	// 2 more false blockVotes (2 blocks)
@@ -975,7 +975,7 @@ func TestPRepStatusState_NotifyEvent(t *testing.T) {
 	assert.True(t, ps.IsUnjailable())
 	assert.False(t, ps.IsJailInfoElectable())
 	assert.Zero(t, ps.UnjailRequestHeight())
-	assert.Zero(t, ps.MinDoubleVoteHeight())
+	assert.Zero(t, ps.MinDoubleSignHeight())
 	assert.Equal(t, JFlagInJail, ps.JailFlags())
 	assert.Equal(t, oTotal, ps.GetVTotal(sc.BlockHeight()))
 	assert.Equal(t, oFail, ps.GetVFail(sc.BlockHeight()))
@@ -994,7 +994,7 @@ func TestPRepStatusState_NotifyEvent(t *testing.T) {
 	assert.False(t, ps.IsUnjailable())
 	assert.True(t, ps.IsJailInfoElectable())
 	assert.Equal(t, sc.BlockHeight(), ps.UnjailRequestHeight())
-	assert.Zero(t, ps.MinDoubleVoteHeight())
+	assert.Zero(t, ps.MinDoubleSignHeight())
 	assert.Equal(t, oTotal, ps.GetVTotal(sc.BlockHeight()))
 	assert.Equal(t, oFail, ps.GetVFail(sc.BlockHeight()))
 	assert.Equal(t, oFailCont, ps.GetVFailCont(sc.BlockHeight()))
@@ -1016,7 +1016,7 @@ func TestPRepStatusState_NotifyEvent(t *testing.T) {
 	assert.False(t, ps.IsUnjailable())
 	assert.True(t, ps.IsJailInfoElectable())
 	assert.Zero(t, ps.UnjailRequestHeight())
-	assert.Zero(t, ps.MinDoubleVoteHeight())
+	assert.Zero(t, ps.MinDoubleSignHeight())
 	assert.Equal(t, oTotal, ps.GetVTotal(sc.BlockHeight()))
 	assert.Equal(t, oFail, ps.GetVFail(sc.BlockHeight()))
 	assert.Zero(t, ps.GetVFailCont(sc.BlockHeight()))

--- a/icon/iiss/icstate/prepstatus_test.go
+++ b/icon/iiss/icstate/prepstatus_test.go
@@ -1021,3 +1021,17 @@ func TestPRepStatusState_NotifyEvent(t *testing.T) {
 	assert.Equal(t, oFail, ps.GetVFail(sc.BlockHeight()))
 	assert.Zero(t, ps.GetVFailCont(sc.BlockHeight()))
 }
+
+// Assume that IsDoubleSignReportable() is called after RevisionIISS4
+func TestPRepStatus_IsDoubleSignReportable(t *testing.T) {
+	owner := newDummyAddress(1)
+	sc := newMockStateContext(map[string]interface{}{"blockHeight": int64(1000), "revision": icmodule.RevisionIISS4})
+
+	ps := NewPRepStatus(owner)
+	assert.NoError(t, ps.Activate())
+	assert.Equal(t, GradeCandidate, ps.Grade())
+	assert.Equal(t, None, ps.LastState())
+	assert.True(t, ps.IsActive())
+
+	assert.True(t, ps.IsDoubleSignReportable(sc, int64(1000)))
+}

--- a/icon/iiss/icstate/state_test.go
+++ b/icon/iiss/icstate/state_test.go
@@ -642,7 +642,7 @@ func TestState_ImposePenalty(t *testing.T) {
 			input{
 				icmodule.RevisionIISS4 - 1,
 				icmodule.RevisionIISS4 - 1,
-				icmodule.PenaltyDoubleVote,
+				icmodule.PenaltyDoubleSign,
 			},
 			output{0},
 		},
@@ -650,7 +650,7 @@ func TestState_ImposePenalty(t *testing.T) {
 			input{
 				icmodule.RevisionIISS4,
 				icmodule.RevisionIISS4 - 1,
-				icmodule.PenaltyDoubleVote,
+				icmodule.PenaltyDoubleSign,
 			},
 			output{0},
 		},
@@ -658,25 +658,25 @@ func TestState_ImposePenalty(t *testing.T) {
 			input{
 				icmodule.RevisionIISS4,
 				icmodule.RevisionIISS4,
-				icmodule.PenaltyDoubleVote,
+				icmodule.PenaltyDoubleSign,
 			},
-			output{JFlagInJail | JFlagDoubleVote},
+			output{JFlagInJail | JFlagDoubleSign},
 		},
 		{
 			input{
 				icmodule.RevisionIISS4 + 1,
 				icmodule.RevisionIISS4,
-				icmodule.PenaltyDoubleVote,
+				icmodule.PenaltyDoubleSign,
 			},
-			output{JFlagInJail | JFlagDoubleVote},
+			output{JFlagInJail | JFlagDoubleSign},
 		},
 		{
 			input{
 				icmodule.RevisionIISS4 + 1,
 				icmodule.RevisionIISS4 + 1,
-				icmodule.PenaltyDoubleVote,
+				icmodule.PenaltyDoubleSign,
 			},
-			output{JFlagInJail | JFlagDoubleVote},
+			output{JFlagInJail | JFlagDoubleSign},
 		},
 	}
 
@@ -710,7 +710,7 @@ func TestState_ImposePenalty(t *testing.T) {
 
 			assert.Equal(t, arg.out.jailFlags, ps.JailFlags())
 			assert.Zero(t, ps.UnjailRequestHeight())
-			assert.Zero(t, ps.MinDoubleVoteHeight())
+			assert.Zero(t, ps.MinDoubleSignHeight())
 		})
 	}
 }

--- a/icon/revision.go
+++ b/icon/revision.go
@@ -307,7 +307,7 @@ func onRevision23(s *chainScore, _ int) error {
 			{icmodule.PenaltyAccumulatedValidationFailure, icmodule.DefaultContinuousBlockValidationSlashingRate},
 			{icmodule.PenaltyValidationFailure, icmodule.DefaultBlockValidationSlashingRate},
 			{icmodule.PenaltyMissedNetworkProposalVote, icmodule.DefaultMissingNetworkProposalVoteSlashingRate},
-			{icmodule.PenaltyDoubleVote, icmodule.DefaultDoubleVoteSlashingRate},
+			{icmodule.PenaltyDoubleSign, icmodule.DefaultDoubleSignSlashingRate},
 		}
 		for _, item := range items {
 			if err := es.State.SetSlashingRate(revision, item.pt, item.rate); err != nil {


### PR DESCRIPTION
- Introduce DoubleSignReported(Address,int,str) eventLog
- Rename DoubleVote to DoubleSign
- Test DoubleSignReport with Simulator