### PR TITLE
Migrate SlashingRates on Rev23

### DIFF
--- a/icon/icmodule/constant.go
+++ b/icon/icmodule/constant.go
@@ -76,13 +76,6 @@ const (
 	DefaultDelegationSlotMax                    = 100
 	DefaultExtraMainPRepCount                   = 3
 	DefaultNonVotePenaltySlashRate              = 0 // 0%
-
-	// IISS-4.0
-	DefaultPRepDisqualificationSlashingRate       = Rate(DenomInRate) // 100%
-	DefaultContinuousBlockValidationSlashingRate  = Rate(1)           // 0.01%
-	DefaultBlockValidationSlashingRate            = Rate(0)           // 0%
-	DefaultMissingNetworkProposalVoteSlashingRate = Rate(1)           // 0.01%
-	DefaultDoubleSignSlashingRate                 = Rate(1000)        // 10%
 )
 
 // The following variables are read-only
@@ -93,7 +86,6 @@ var (
 	BigIntMinIRep        = new(big.Int).Mul(big.NewInt(MinIRep), BigIntICX)
 	BigIntIScoreICXRatio = big.NewInt(IScoreICXRatio)
 	BigIntRegPRepFee     = new(big.Int).Mul(big.NewInt(2000), BigIntICX)
-	BigIntDayBlocks      = big.NewInt(DayBlock)
 
 	DefaultMinBond = new(big.Int).Mul(big.NewInt(10_000), BigIntICX)
 )

--- a/icon/revision.go
+++ b/icon/revision.go
@@ -282,8 +282,8 @@ func onRevision21(s *chainScore, _ int) error {
 	return nil
 }
 
+// onRevision23 handles states in PreIISS4 phase
 func onRevision23(s *chainScore, _ int) error {
-	revision := icmodule.RevisionPreIISS4
 	es := s.cc.GetExtensionState().(*iiss.ExtensionStateImpl)
 
 	// RewardFundAllocation2
@@ -297,27 +297,10 @@ func onRevision23(s *chainScore, _ int) error {
 		return err
 	}
 
-	// slashing rate
-	if s.cc.ChainID() == CIDForMainNet {
-		items := []struct {
-			pt   icmodule.PenaltyType
-			rate icmodule.Rate
-		}{
-			{icmodule.PenaltyPRepDisqualification, icmodule.DefaultPRepDisqualificationSlashingRate},
-			{icmodule.PenaltyAccumulatedValidationFailure, icmodule.DefaultContinuousBlockValidationSlashingRate},
-			{icmodule.PenaltyValidationFailure, icmodule.DefaultBlockValidationSlashingRate},
-			{icmodule.PenaltyMissedNetworkProposalVote, icmodule.DefaultMissingNetworkProposalVoteSlashingRate},
-			{icmodule.PenaltyDoubleSign, icmodule.DefaultDoubleSignSlashingRate},
-		}
-		for _, item := range items {
-			if err := es.State.SetSlashingRate(revision, item.pt, item.rate); err != nil {
-				return err
-			}
-		}
-	}
 	return nil
 }
 
+// onRevision24 handles states in IISS4 phase
 func onRevision24(s *chainScore, _ int) error {
 	es := s.cc.GetExtensionState().(*iiss.ExtensionStateImpl)
 


### PR DESCRIPTION
* Remove to set slashingRates by default from onRevision23() on MainNet
* Migrate slashingRates for AccumulatedValidationFailure and MissedNetworkProposalVote on Revision23