### PR TITLE
Do not set 10,000 ICX to minimumBond by default

### DIFF
--- a/icon/icmodule/constant.go
+++ b/icon/icmodule/constant.go
@@ -86,8 +86,6 @@ var (
 	BigIntMinIRep        = new(big.Int).Mul(big.NewInt(MinIRep), BigIntICX)
 	BigIntIScoreICXRatio = big.NewInt(IScoreICXRatio)
 	BigIntRegPRepFee     = new(big.Int).Mul(big.NewInt(2000), BigIntICX)
-
-	DefaultMinBond = new(big.Int).Mul(big.NewInt(10_000), BigIntICX)
 )
 
 var BlockedAccount = map[string]bool{

--- a/icon/icsim/revision.go
+++ b/icon/icsim/revision.go
@@ -244,11 +244,7 @@ func (sim *simulatorImpl) handleRev23(ws state.WorldState) error {
 
 	// RewardFundAllocation2
 	r := es.State.GetRewardFundV1()
-	if err := es.State.SetRewardFund(r.ToRewardFundV2()); err != nil {
-		return err
-	}
-	// minBond for minimum wage
-	return es.State.SetMinimumBond(icmodule.DefaultMinBond)
+	return es.State.SetRewardFund(r.ToRewardFundV2())
 }
 
 func (sim *simulatorImpl) handleRev24(ws state.WorldState) error {

--- a/icon/iiss/icstate/networkvalue.go
+++ b/icon/iiss/icstate/networkvalue.go
@@ -452,7 +452,11 @@ func (s *State) setSlashingRate(penaltyType icmodule.PenaltyType, rate icmodule.
 // GetMinimumBond returns the minimum bond related to minimum wage
 // It returns nil before RevisionIISS4R0
 func (s *State) GetMinimumBond() *big.Int {
-	return getValue(s.store, VarMinBond).BigInt()
+	ret := getValue(s.store, VarMinBond).BigInt()
+	if ret == nil {
+		ret = icmodule.BigIntZero
+	}
+	return ret
 }
 
 func (s *State) SetMinimumBond(bond *big.Int) error {

--- a/icon/iiss/icstate/networkvalue_test.go
+++ b/icon/iiss/icstate/networkvalue_test.go
@@ -620,7 +620,7 @@ func TestState_SetMinimumBond(t *testing.T) {
 	s := newDummyState(false)
 
 	bond := s.GetMinimumBond()
-	assert.Nil(t, bond)
+	assert.Zero(t, bond.Sign())
 
 	args := []struct {
 		bond    *big.Int

--- a/icon/iiss/icstate/term_test.go
+++ b/icon/iiss/icstate/term_test.go
@@ -70,7 +70,7 @@ func newTermState(version, sequence int, period int64) *TermState {
 		rf = newTestRewardFundV1()
 	} else {
 		rf = newTestRewardFundV2()
-		mb = icmodule.DefaultMinBond
+		mb = icmodule.BigIntZero
 	}
 	return &TermState{
 		termData: termData{
@@ -300,7 +300,7 @@ func TestTermSnapshot_RLPDecodeFields(t *testing.T) {
 			rrep = icmodule.BigIntZero
 		} else {
 			rf = rf2
-			mb = icmodule.DefaultMinBond
+			mb = icmodule.BigIntZero
 		}
 		termState := &TermState{
 			termData: termData{

--- a/icon/revision.go
+++ b/icon/revision.go
@@ -327,11 +327,6 @@ func onRevIISS4R0(s *chainScore, rev, _ int) error {
 		return err
 	}
 
-	// minBond for minimum wage
-	if err := es.State.SetMinimumBond(icmodule.DefaultMinBond); err != nil {
-		return err
-	}
-
 	// slashingRates migration for AccumulatedValidationFailure and MissedNetworkProposalVote
 	for _, pt := range []icmodule.PenaltyType{
 		icmodule.PenaltyAccumulatedValidationFailure,


### PR DESCRIPTION
- Remove minimumBond setting code from onRevIISS4R0()
- Remove DefaultMinBond variable from constant.go
