### PR TITLE
prepSetImpl refactoring and trivial updates

### DIFF
--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -926,13 +926,10 @@ func (s *chainScore) Ex_setMinimumBond(nBond *big.Int) error {
 		return scoreresult.InvalidParameterError.New("NegativeMinimumBond")
 	}
 	oBond := es.State.GetMinimumBond()
-	if oBond == nil {
-		return icmodule.NotFoundError.New("MinimumBondNotFound")
-	}
 	if oBond.Cmp(nBond) == 0 {
 		return nil
 	}
-	if err = es.State.SetMinimumBond(new(big.Int).Set(nBond)); err != nil {
+	if err = es.State.SetMinimumBond(nBond); err != nil {
 		return scoreresult.InvalidParameterError.Wrapf(
 			err,
 			"Failed to set minimum bond: bond=%d",

--- a/icon/icsim/doublesign_test.go
+++ b/icon/icsim/doublesign_test.go
@@ -70,7 +70,7 @@ func TestDoubleSign_RequestUnjailNormalCase(t *testing.T) {
 	// Check the status of prep0
 	prep = sim.GetPRep(prep0)
 	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
-	assert.True(t, icutils.MatchAll(prep.JailFlags(), icstate.JFlagInJail|icstate.JFlagDoubleSign))
+	assert.True(t, icutils.ContainsAll(prep.JailFlags(), icstate.JFlagInJail|icstate.JFlagDoubleSign))
 	assert.Zero(t, prep.MinDoubleSignHeight())
 	// Check the status of prep0Sub(prep25)
 	prep = sim.GetPRep(prep0Sub)
@@ -97,7 +97,7 @@ func TestDoubleSign_RequestUnjailNormalCase(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, CheckReceiptSuccess(rcpt))
 	prep = sim.GetPRep(prep0)
-	assert.True(t, icutils.MatchAll(
+	assert.True(t, icutils.ContainsAll(
 		prep.JailFlags(), icstate.JFlagUnjailing|icstate.JFlagDoubleSign|icstate.JFlagInJail))
 	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
 	assert.True(t, prep.IsJailInfoElectable())
@@ -180,7 +180,7 @@ func TestHandleDoubleSignReport_Slashing(t *testing.T) {
 	// Check the status of prep0
 	prep = sim.GetPRep(prep0)
 	assert.Equal(t, icstate.GradeCandidate, prep.Grade())
-	assert.True(t, icutils.MatchAll(prep.JailFlags(), icstate.JFlagInJail|icstate.JFlagDoubleSign))
+	assert.True(t, icutils.ContainsAll(prep.JailFlags(), icstate.JFlagInJail|icstate.JFlagDoubleSign))
 	assert.Zero(t, prep.MinDoubleSignHeight())
 	// Check the status of prep0Sub(prep25)
 	prep = sim.GetPRep(prep0Sub)

--- a/icon/iiss/icstate/jailinfo.go
+++ b/icon/iiss/icstate/jailinfo.go
@@ -28,11 +28,11 @@ func (ji *JailInfo) Flags() int {
 }
 
 func (ji *JailInfo) IsInJail() bool {
-	return icutils.MatchAll(ji.flags, JFlagInJail)
+	return icutils.ContainsAll(ji.flags, JFlagInJail)
 }
 
 func (ji *JailInfo) IsUnjailing() bool {
-	return icutils.MatchAll(ji.flags, JFlagUnjailing)
+	return icutils.ContainsAll(ji.flags, JFlagUnjailing)
 }
 
 func (ji *JailInfo) IsUnjailable() bool {
@@ -113,11 +113,11 @@ func (ji *JailInfo) OnMainPRepIn(sc icmodule.StateContext) error {
 	if sc.TermIISSVersion() < IISSVersion4 {
 		return nil
 	}
-	if icutils.MatchAll(ji.flags, JFlagInJail) {
-		if !icutils.MatchAll(ji.flags, JFlagUnjailing) {
+	if icutils.ContainsAll(ji.flags, JFlagInJail) {
+		if !icutils.ContainsAll(ji.flags, JFlagUnjailing) {
 			return icmodule.InvalidStateError.Errorf("InvalidJailFlags(%d)", ji.flags)
 		}
-		if icutils.MatchAll(ji.flags, JFlagDoubleSign) {
+		if icutils.ContainsAll(ji.flags, JFlagDoubleSign) {
 			ji.minDoubleSignHeight = sc.BlockHeight()
 		}
 		ji.flags = 0

--- a/icon/iiss/icstate/jailinfo_test.go
+++ b/icon/iiss/icstate/jailinfo_test.go
@@ -36,10 +36,10 @@ func checkUnjailRequestHeight(t *testing.T, ji *JailInfo, unjailRequestHeight in
 }
 
 func newJailInfo(flags int, unjailRequestHeight, minDoubleSignHeight int64) *JailInfo {
-	if !icutils.MatchAll(flags, JFlagUnjailing) && unjailRequestHeight != 0 {
+	if !icutils.ContainsAll(flags, JFlagUnjailing) && unjailRequestHeight != 0 {
 		return nil
 	}
-	if icutils.MatchAny(flags, ^(JFlagMax - 1)) {
+	if icutils.ContainsAny(flags, ^(JFlagMax - 1)) {
 		return nil
 	}
 	return &JailInfo{flags, unjailRequestHeight, minDoubleSignHeight}
@@ -150,7 +150,7 @@ func TestJailInfo_OnPenaltyImposed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			in := arg.in
 			out := arg.out
-			if icutils.MatchAll(in.flags, JFlagUnjailing) {
+			if icutils.ContainsAll(in.flags, JFlagUnjailing) {
 				unjailRequestHeight = int64(500)
 			} else {
 				unjailRequestHeight = int64(0)
@@ -404,7 +404,7 @@ func TestJailInfo_IsFunctions(t *testing.T) {
 			assert.Equal(t, arg.out.electable, ji.IsElectable())
 			assert.Equal(t, arg.out.inJail, ji.IsInJail())
 			assert.Equal(t, arg.out.unjailing, ji.IsUnjailing())
-			assert.Equal(t, arg.out.inDoubleSignPenalty, icutils.MatchAll(ji.Flags(), JFlagDoubleSign))
+			assert.Equal(t, arg.out.inDoubleSignPenalty, icutils.ContainsAll(ji.Flags(), JFlagDoubleSign))
 		})
 	}
 }

--- a/icon/iiss/icstate/prep.go
+++ b/icon/iiss/icstate/prep.go
@@ -116,23 +116,20 @@ type PRepSet interface {
 }
 
 type prepSetImpl struct {
-	mainPReps []*PRep // with extraMainPReps
-	subPReps  []*PRep
-	preps     []*PRep
+	mainPRepCount    int // including extraMainPReps
+	electedPRepCount int
+	// | mainPReps | extraMainPReps | subPReps |
+	preps            []*PRep
 }
 
 func (p *prepSetImpl) OnTermEnd(sc icmodule.StateContext, limit int) error {
 	// Assume that p.preps has been already sorted properly according to the current revision
 	var newGrade Grade
-	mainPRepCount := len(p.mainPReps)
-	subPRepCount := len(p.subPReps)
-	electedPRepCount := mainPRepCount + subPRepCount
-
 	for i, prep := range p.preps {
-		if i < mainPRepCount {
+		if i < p.mainPRepCount {
 			// Prevent a prep with 0 power from being an extra main prep
 			newGrade = GradeMain
-		} else if i < electedPRepCount {
+		} else if i < p.electedPRepCount {
 			newGrade = GradeSub
 		} else {
 			newGrade = GradeCandidate
@@ -148,11 +145,11 @@ func (p *prepSetImpl) OnTermEnd(sc icmodule.StateContext, limit int) error {
 func (p *prepSetImpl) GetPRepSize(grade Grade) int {
 	switch grade {
 	case GradeMain:
-		return len(p.mainPReps)
+		return p.mainPRepCount
 	case GradeSub:
-		return len(p.subPReps)
+		return p.electedPRepCount - p.mainPRepCount
 	case GradeCandidate:
-		return p.Size() - len(p.mainPReps) - len(p.subPReps)
+		return p.Size() - p.electedPRepCount
 	default:
 		panic(errors.Errorf("Invalid grade: %d", grade))
 	}
@@ -170,7 +167,7 @@ func (p *prepSetImpl) GetByIndex(i int) *PRep {
 }
 
 func (p *prepSetImpl) ToPRepSnapshots(br icmodule.Rate) PRepSnapshots {
-	size := len(p.mainPReps) + len(p.subPReps)
+	size := p.electedPRepCount
 	if size == 0 {
 		return nil
 	}
@@ -184,7 +181,7 @@ func (p *prepSetImpl) ToPRepSnapshots(br icmodule.Rate) PRepSnapshots {
 }
 
 // Sort sorts the PRepSet based on predefined criteria that may change with each revision
-// PRepCount parameters are the metrics in configuration file
+// PRepCount parameters are the metrics in network value configuration
 // Ex) mainPRepCount(22), subPRepCount(78), extraMainPRepCount(3)
 func (p *prepSetImpl) init(sc icmodule.StateContext, cfg PRepCountConfig) {
 	rev := sc.RevisionValue()
@@ -232,25 +229,74 @@ func (p *prepSetImpl) sortBeforeRevBTP2(sc icmodule.StateContext, cfg PRepCountC
 	SortByPower(sc, p.preps)
 
 	size := len(p.preps)
-	mainPRepCount := cfg.MainPReps()
 
-	if size <= mainPRepCount {
-		// Not enough number of active preps to be extra main preps
-		p.classifyPReps(size, size)
-		return
-	}
-
-	// electedPRepCount MUST BE larger than mainPRepCount
-	electedPRepCount := icutils.Min(size, cfg.ElectedPReps())
+	mainPRepCount := icutils.Min(cfg.MainPReps(), size)
+	electedPRepCount := icutils.Min(cfg.ElectedPReps(), size)
 	extraMainPRepCount := icutils.Min(cfg.ExtraMainPReps(), electedPRepCount-mainPRepCount)
 
 	if sc.RevisionValue() < icmodule.RevisionExtraMainPReps || extraMainPRepCount <= 0 {
 		// No need to find extraMainPReps
-		p.classifyPReps(mainPRepCount, electedPRepCount)
+		p.setPRepCounts(mainPRepCount, electedPRepCount)
 		return
 	}
 
-	// Move extraMainPReps into the place between mainPReps and subPReps
+	// Find extraMainPReps
+
+	// Copy sub preps from preps to subPReps
+	subPReps := p.preps[mainPRepCount:electedPRepCount]
+	dupSubPReps := make([]*PRep, len(subPReps))
+	copy(dupSubPReps, subPReps)
+
+	// sort subPReps by LRU logic
+	// Priority: low lastBH, high power, high address
+	sortByLRU(sc, subPReps)
+
+	// Find eligible extraMainPReps in subPReps
+	br := sc.GetBondRequirement()
+	extraMainPReps := chooseExtraMainPReps(subPReps, extraMainPRepCount, func(prep *PRep) bool {
+		return prep.GetPower(br).Sign() > 0
+	})
+	copy(subPReps, extraMainPReps)
+	extraMainPRepCount = len(extraMainPReps)
+
+	// Move the extraMainPReps found above to the front of other subPReps,
+	// filling excludePReps map with extraMainPReps
+	excludePReps := make(map[string]bool)
+	for _, prep := range extraMainPReps {
+		excludePReps[icutils.ToKey(prep.Owner())] = true
+	}
+
+	// Append remaining subPReps excluding extraMainPReps
+	// p.preps: | MainPReps | ExtraMainPReps | SubPReps |
+	copyPReps(subPReps[extraMainPRepCount:], dupSubPReps, excludePReps)
+	p.setPRepCounts(mainPRepCount+extraMainPRepCount, electedPRepCount)
+}
+
+func (p *prepSetImpl) sortAfterRevBTP2(sc icmodule.StateContext, cfg PRepCountConfig) {
+	// All counts are configuration values; Default: 22, 78, 3
+	SortByPower(sc, p.preps)
+
+	// Count the number of electable PReps
+	size := 0
+	for _, prep := range p.preps {
+		if prep.IsElectable(sc) {
+			size++
+		}
+	}
+
+	mainPRepCount := icutils.Min(cfg.MainPReps(), size)
+	electedPRepCount := icutils.Min(cfg.ElectedPReps(), size)
+	extraMainPRepCount := icutils.Min(cfg.ExtraMainPReps(), electedPRepCount-mainPRepCount)
+
+	if extraMainPRepCount <= 0 {
+		// No need to find extra MainPReps
+		p.setPRepCounts(mainPRepCount, electedPRepCount)
+		return
+	}
+
+	// Find extraMainPReps
+
+	// Copy sub preps from preps to subPReps
 	subPReps := p.preps[mainPRepCount:electedPRepCount]
 	dupSubPReps := make([]*PRep, len(subPReps))
 	copy(dupSubPReps, subPReps)
@@ -259,84 +305,26 @@ func (p *prepSetImpl) sortBeforeRevBTP2(sc icmodule.StateContext, cfg PRepCountC
 	// Priority: low unjailRequestBH, low lastBH, high power, high address
 	sortByLRU(sc, subPReps)
 
-	// Find eligible extraMainPReps in subPReps
-	br := sc.GetBondRequirement()
-	extraMainPReps := chooseExtraMainPReps(subPReps, extraMainPRepCount, func(prep *PRep) bool {
-		return prep.GetPower(br).Sign() > 0
-	})
-
-	// Move the extraMainPReps found above to the front of other subPReps,
-	// filling excludePReps map with extraMainPReps
+	// Add extra main preps to map
 	excludePReps := make(map[string]bool)
-	for _, prep := range extraMainPReps {
-		subPReps[len(excludePReps)] = prep
-		excludePReps[icutils.ToKey(prep.Owner())] = true
+	for i := 0; i < extraMainPRepCount; i++ {
+		// Assume that subPReps are electable
+		excludePReps[icutils.ToKey(subPReps[i].Owner())] = true
 	}
 
 	// Append remaining subPReps excluding extraMainPReps
-	extraMainPRepCount = len(extraMainPReps)
-	copyPReps(dupSubPReps, subPReps[extraMainPRepCount:], excludePReps)
-	p.classifyPReps(mainPRepCount+extraMainPRepCount, electedPRepCount)
+	// p.preps: | MainPReps | ExtraMainPReps | SubPReps |
+	copyPReps(subPReps[extraMainPRepCount:], dupSubPReps, excludePReps)
+	p.setPRepCounts(mainPRepCount+extraMainPRepCount, electedPRepCount)
 }
 
-func (p *prepSetImpl) sortAfterRevBTP2(sc icmodule.StateContext, cfg PRepCountConfig) {
-	// All counts are configuration values; Default: 22, 78, 3
-	mainPRepCount := cfg.MainPReps()
-
-	SortByPower(sc, p.preps)
-
-	// Count the number of electable PReps
-	electablePReps := 0
-	for _, prep := range p.preps {
-		if prep.IsElectable(sc) {
-			electablePReps++
-		}
-	}
-
-	extraMainPRepCount := icutils.Min(cfg.ExtraMainPReps(), electablePReps-mainPRepCount)
-	if extraMainPRepCount <= 0 {
-		// No need to find extra MainPReps
-		p.classifyPReps(electablePReps, electablePReps)
-		return
-	}
-
-	// maximum number of elected PReps
-	electedPRepCount := icutils.Min(electablePReps, cfg.ElectedPReps())
-
-	// Copy sub preps from preps to subPReps
-	subPReps := p.preps[mainPRepCount:electedPRepCount]
-	dupSubPReps := make([]*PRep, len(subPReps))
-	copy(dupSubPReps, subPReps)
-
-	// sort subPReps by LRU logic
-	// Priority: older unjailRequestBH, older lastBH, higher power, higher address
-	sortByLRU(sc, subPReps)
-
-	if len(subPReps) > extraMainPRepCount {
-		// Add extra main preps to map
-		excludePReps := make(map[string]bool)
-		for i := 0; i < extraMainPRepCount; i++ {
-			// Assume that subPReps are electable
-			excludePReps[icutils.ToKey(subPReps[i].Owner())] = true
-		}
-
-		// Append remaining sub preps excluding extra main preps
-		// p.preps: | MainPReps | ExtraMainPReps | SubPReps |
-		copyPReps(dupSubPReps, subPReps[extraMainPRepCount:], excludePReps)
-	}
-
-	p.classifyPReps(mainPRepCount+extraMainPRepCount, electablePReps)
-}
-
-// classifyPReps classifies p.preps by grade
+// setPRepCounts set mainPRepCount and electedPRepCount on PRepSorting finalization
 // mainPReps: # of real mainPReps including extraMainPReps, not config value
 // electedPReps: # of real electedPReps, not config value
-func (p *prepSetImpl) classifyPReps(mainPReps, electedPReps int) {
-	p.mainPReps, p.subPReps = classifyPReps(p.preps, mainPReps, electedPReps)
-}
-
-func classifyPReps(preps []*PRep, mainPReps, electedPReps int) ([]*PRep, []*PRep) {
-	return preps[:mainPReps], preps[mainPReps:electedPReps]
+func (p *prepSetImpl) setPRepCounts(mainPRepCount, electedPRepCount int) {
+	// including extraMainPReps
+	p.mainPRepCount = mainPRepCount
+	p.electedPRepCount = electedPRepCount
 }
 
 func chooseExtraMainPReps(preps []*PRep, size int, isOk func(prep *PRep) bool) []*PRep {
@@ -352,7 +340,7 @@ func chooseExtraMainPReps(preps []*PRep, size int, isOk func(prep *PRep) bool) [
 	return extras
 }
 
-func copyPReps(srcPReps, dstPReps []*PRep, excludeMap map[string]bool) {
+func copyPReps(dstPReps, srcPReps []*PRep, excludeMap map[string]bool) {
 	i := 0
 	for _, prep := range srcPReps {
 		if excludeMap == nil || !excludeMap[icutils.ToKey(prep.Owner())] {

--- a/icon/iiss/icstate/prep_test.go
+++ b/icon/iiss/icstate/prep_test.go
@@ -486,7 +486,7 @@ func TestCopyPReps(t *testing.T) {
 		}
 
 		t.Run(name, func(t *testing.T) {
-			copyPReps(srcPReps, dstPReps, excludeMap)
+			copyPReps(dstPReps, srcPReps, excludeMap)
 			nils := 0
 			for _, prep := range dstPReps {
 				if prep == nil {
@@ -496,31 +496,6 @@ func TestCopyPReps(t *testing.T) {
 				}
 			}
 			assert.Equal(t, nils, len(excludeMap))
-		})
-	}
-}
-
-func TestClassifyPReps(t *testing.T) {
-	preps := newDummyPReps(10)
-	args := []struct {
-		main    int
-		elected int
-	}{
-		{10, 10},
-		{3, 7},
-		{3, 5},
-		{7, 7},
-	}
-
-	for i, arg := range args {
-		name := fmt.Sprintf("case-%02d", i)
-		main := arg.main
-		elected := arg.elected
-
-		t.Run(name, func(t *testing.T) {
-			mainPReps, subPReps := classifyPReps(preps, main, elected)
-			assert.Equal(t, main, len(mainPReps))
-			assert.Equal(t, elected-main, len(subPReps))
 		})
 	}
 }

--- a/icon/iiss/icstate/prepstatus.go
+++ b/icon/iiss/icstate/prepstatus.go
@@ -328,11 +328,11 @@ func (ps *prepStatusData) getPenaltyTypeV1() icmodule.PenaltyType {
 	if ps.status == Disqualified {
 		return icmodule.PenaltyPRepDisqualification
 	}
-	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleSign) {
+	if icutils.ContainsAll(ps.ji.Flags(), JFlagDoubleSign) {
 		return icmodule.PenaltyDoubleSign
 	}
 	if (ps.vPenaltyMask & 1) != 0 {
-		if icutils.MatchAll(ps.ji.Flags(), JFlagAccumulatedValidationFailure) {
+		if icutils.ContainsAll(ps.ji.Flags(), JFlagAccumulatedValidationFailure) {
 			return icmodule.PenaltyAccumulatedValidationFailure
 		}
 		return icmodule.PenaltyValidationFailure
@@ -456,7 +456,7 @@ func (ps *prepStatusData) IsDoubleSignReportable(sc icmodule.StateContext, dsBlo
 	if !ps.IsActive() {
 		return false
 	}
-	if icutils.MatchAll(ps.ji.Flags(), JFlagDoubleSign) {
+	if icutils.ContainsAll(ps.ji.Flags(), JFlagDoubleSign) {
 		// Already in Jail due to DoubleSignReport
 		return false
 	}

--- a/icon/iiss/icutils/utils.go
+++ b/icon/iiss/icutils/utils.go
@@ -30,7 +30,6 @@ import (
 	"github.com/icon-project/goloop/common/log"
 	"github.com/icon-project/goloop/icon/icmodule"
 	"github.com/icon-project/goloop/module"
-	"github.com/icon-project/goloop/service/scoreresult"
 )
 
 const (
@@ -262,11 +261,4 @@ func MatchAll(flags, flag int) bool {
 
 func MatchAny(flags, flag int) bool {
 	return flags&flag != 0
-}
-
-func CheckInt64Overflow(value *big.Int) error {
-	if !value.IsInt64() {
-		return scoreresult.InvalidParameterError.Errorf("Int64Overflow(0x%x)", value)
-	}
-	return nil
 }

--- a/icon/iiss/icutils/utils.go
+++ b/icon/iiss/icutils/utils.go
@@ -255,10 +255,10 @@ func CalcPower(br icmodule.Rate, bonded, voted *big.Int) *big.Int {
 	return MinBigInt(power, voted)
 }
 
-func MatchAll(flags, flag int) bool {
+func ContainsAll(flags, flag int) bool {
 	return flags&flag == flag
 }
 
-func MatchAny(flags, flag int) bool {
+func ContainsAny(flags, flag int) bool {
 	return flags&flag != 0
 }

--- a/icon/iiss/icutils/utils_test.go
+++ b/icon/iiss/icutils/utils_test.go
@@ -504,7 +504,7 @@ func TestMatchAll(t *testing.T) {
 	for i, arg := range args {
 		name := fmt.Sprintf("name-%02d", i)
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, arg.success, MatchAll(arg.flags, arg.flag))
+			assert.Equal(t, arg.success, ContainsAll(arg.flags, arg.flag))
 		})
 	}
 }
@@ -528,7 +528,7 @@ func TestMatchAny(t *testing.T) {
 	for i, arg := range args {
 		name := fmt.Sprintf("name-%02d", i)
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, arg.success, MatchAny(arg.flags, arg.flag))
+			assert.Equal(t, arg.success, ContainsAny(arg.flags, arg.flag))
 		})
 	}
 }

--- a/icon/iiss/icutils/utils_test.go
+++ b/icon/iiss/icutils/utils_test.go
@@ -532,36 +532,3 @@ func TestMatchAny(t *testing.T) {
 		})
 	}
 }
-
-func TestCheckInt64Overflow(t *testing.T) {
-	args := []struct {
-		text     string
-		overflow bool
-	}{
-		{"0x1234567890123456", false},
-		{"-0x1", false},
-		{"-0x0", false},
-		{"0x7fffffffffffffff", false},
-		{"-0x7fffffffffffffff", false},
-		{"0x8000000000000000", true},
-		{"0xffffffffffffffff", true},
-		{"-0xffffffffffffffff", true},
-		{"0x1ffffffffffffffff", true},
-		{"0x12345678901234567890", true},
-	}
-	for _, arg := range args {
-		value := new(big.Int)
-		_, ok := value.SetString(arg.text, 0)
-		assert.True(t, ok)
-
-		name := fmt.Sprintf("case %x %t", value, ok)
-		t.Run(name, func(t *testing.T) {
-			err := CheckInt64Overflow(value)
-			if arg.overflow {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}


### PR DESCRIPTION
* Remove unused CheckInt64Overflow() function from icutils
* Remove redundant code from Ex_setMinimumBond()
* Refactor prepSetImpl used for Validator Election
* Rename MatchAll() and MatchAny() to ContainsAll() and ContainsAny() in icutils package