### PR TITLE
Refactor icstate/term.go

### DIFF
--- a/icon/icsim/prepcountconfig_test.go
+++ b/icon/icsim/prepcountconfig_test.go
@@ -80,9 +80,8 @@ func TestSimulatorImpl_SetPRepCountConfig(t *testing.T) {
 	assert.Equal(t, int(newSubPRepCount-newExtraMainPRepCount), len(subPReps))
 
 	term := sim.TermSnapshot()
-	for i := 0; i < term.GetPRepSnapshotCount(); i++ {
-		prepSnapshot := term.GetPRepSnapshotByIndex(i)
-		prep := sim.GetPRep(prepSnapshot.Owner())
+	for i, pss := range term.PRepSnapshots() {
+		prep := sim.GetPRep(pss.Owner())
 		if i < int(newMainPRepCount+newExtraMainPRepCount) {
 			assert.Equal(t, icstate.GradeMain, prep.Grade())
 		} else {

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -1029,10 +1029,10 @@ func (es *ExtensionStateImpl) setIrepToTerm(revision int, preps icstate.PRepSet,
 	var irep *big.Int
 	if revision < icmodule.RevisionDecentralize || revision >= icmodule.RevisionEnableIISS3 {
 		// disable IRep
-		irep = new(big.Int)
+		irep = icmodule.BigIntZero
 	} else if revision >= icmodule.RevisionSetIRepViaNetworkProposal {
 		// use network value IRep
-		irep = new(big.Int).Set(es.State.GetIRep())
+		irep = es.State.GetIRep()
 	} else {
 		irep = calculateIRep(preps)
 	}
@@ -1043,7 +1043,7 @@ func (es *ExtensionStateImpl) setRrepToTerm(revision int, totalSupply *big.Int, 
 	var rrep *big.Int
 	if revision < icmodule.RevisionIISS || revision >= icmodule.RevisionEnableIISS3 {
 		// disable Rrep
-		rrep = new(big.Int)
+		rrep = icmodule.BigIntZero
 	} else {
 		rrep = calculateRRep(totalSupply, es.State.GetTotalDelegation())
 	}

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -306,14 +306,12 @@ func (es *ExtensionStateImpl) GetMainPRepsInJSON(blockHeight int64) (map[string]
 		return nil, err
 	}
 
-	pssCount := term.GetPRepSnapshotCount()
 	mainPRepCount := term.MainPRepCount()
 	jso := make(map[string]interface{})
 	preps := make([]interface{}, 0, mainPRepCount)
 	sum := new(big.Int)
 
-	for i := 0; i < pssCount; i++ {
-		pss := term.GetPRepSnapshotByIndex(i)
+	for _, pss := range term.PRepSnapshots() {
 		ps := es.State.GetPRepStatusByOwner(pss.Owner(), false)
 		pb := es.State.GetPRepBaseByOwner(pss.Owner(), false)
 
@@ -338,20 +336,17 @@ func (es *ExtensionStateImpl) GetMainPRepsInJSON(blockHeight int64) (map[string]
 func (es *ExtensionStateImpl) GetSubPRepsInJSON(blockHeight int64) (map[string]interface{}, error) {
 	term := es.State.GetTermSnapshot()
 	if term == nil {
-		err := errors.Errorf("Term is nil")
-		return nil, err
+		return nil, errors.Errorf("Term is nil")
 	}
 
-	pssCount := term.GetPRepSnapshotCount()
+	pssList := term.PRepSnapshots()
 	mainPRepCount := term.MainPRepCount()
-	subPRepCount := term.GetElectedPRepCount() - mainPRepCount
 
 	jso := make(map[string]interface{})
-	preps := make([]interface{}, 0, subPRepCount)
+	preps := make([]interface{}, 0, len(pssList)-mainPRepCount)
 	sum := new(big.Int)
 
-	for i := mainPRepCount; i < pssCount; i++ {
-		pss := term.GetPRepSnapshotByIndex(i)
+	for _, pss := range pssList[mainPRepCount:] {
 		ps := es.State.GetPRepStatusByOwner(pss.Owner(), false)
 		pb := es.State.GetPRepBaseByOwner(pss.Owner(), false)
 

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -247,15 +247,16 @@ func (es *ExtensionStateImpl) setNewFront() (err error) {
 			return
 		}
 	case icstate.IISSVersion3:
+		rf := term.RewardFund()
 		if err = es.Front.AddGlobalV2(
 			term.Revision(),
 			term.StartHeight(),
 			int(term.Period()-1),
-			term.Iglobal(),
-			term.Iprep(),
-			term.Ivoter(),
-			term.Icps(),
-			term.Irelay(),
+			rf.IGlobal(),
+			rf.IPrep(),
+			rf.IVoter(),
+			rf.ICps(),
+			rf.IRelay(),
 			term.GetElectedPRepCount(),
 			term.BondRequirement(),
 		); err != nil {

--- a/icon/iiss/icstate/networkvalue.go
+++ b/icon/iiss/icstate/networkvalue.go
@@ -147,7 +147,11 @@ func (s *State) SetTermPeriod(value int64) error {
 }
 
 func (s *State) GetIRep() *big.Int {
-	return getValue(s.store, VarIRep).BigInt()
+	ret := getValue(s.store, VarIRep).BigInt()
+	if ret == nil {
+		ret = icmodule.BigIntZero
+	}
+	return ret
 }
 
 func (s *State) SetIRep(value *big.Int) error {
@@ -155,7 +159,11 @@ func (s *State) SetIRep(value *big.Int) error {
 }
 
 func (s *State) GetRRep() *big.Int {
-	return getValue(s.store, VarRRep).BigInt()
+	ret := getValue(s.store, VarRRep).BigInt()
+	if ret == nil {
+		ret = icmodule.BigIntZero
+	}
+	return ret
 }
 
 func (s *State) SetRRep(value *big.Int) error {

--- a/icon/iiss/icstate/networkvalue_test.go
+++ b/icon/iiss/icstate/networkvalue_test.go
@@ -108,7 +108,7 @@ func setTermPeriodTest(t *testing.T, s *State) {
 
 func setIRepTest(t *testing.T, s *State) {
 	actual := s.GetIRep()
-	assert.Nil(t, actual)
+	assert.Zero(t, actual.Sign())
 
 	irep := big.NewInt(10)
 	assert.NoError(t, s.SetIRep(irep))
@@ -118,7 +118,7 @@ func setIRepTest(t *testing.T, s *State) {
 
 func setRRepTest(t *testing.T, s *State) {
 	actual := s.GetRRep()
-	assert.Nil(t, actual)
+	assert.Zero(t, actual.Sign())
 
 	rrep := big.NewInt(10)
 	assert.NoError(t, s.SetIRep(rrep))

--- a/icon/iiss/icstate/term.go
+++ b/icon/iiss/icstate/term.go
@@ -112,101 +112,66 @@ const (
 	termVersionReserved
 )
 
-type termData struct {
+type termDataCommon struct {
 	version         int
 	sequence        int
 	startHeight     int64
 	period          int64
 	revision        int
 	isDecentralized bool
-	irep            *big.Int
-	rrep            *big.Int
 	totalSupply     *big.Int
-	totalDelegated  *big.Int // total delegated amount of all active P-Reps. Set with PRepManager.totalDelegated
+	totalDelegated  *big.Int // total delegated amount of all active P-Reps
 	rewardFund      *RewardFund
 	bondRequirement icmodule.Rate
 	mainPRepCount   int
 	// If the length of prepSnapshots is 0, prepSnapshots should be nil
 	prepSnapshots PRepSnapshots
-	minimumBond   *big.Int
 }
 
-func (term *termData) Version() int {
+func (term *termDataCommon) Version() int {
 	return term.version
 }
 
-func (term *termData) Sequence() int {
+func (term *termDataCommon) Sequence() int {
 	return term.sequence
 }
 
-func (term *termData) StartHeight() int64 {
+func (term *termDataCommon) StartHeight() int64 {
 	return term.startHeight
 }
 
-func (term *termData) Period() int64 {
+func (term *termDataCommon) Period() int64 {
 	return term.period
 }
 
-func (term *termData) Irep() *big.Int {
-	return term.irep
-}
-
-func (term *termData) Rrep() *big.Int {
-	return term.rrep
-}
-
-func (term *termData) MainPRepCount() int {
+func (term *termDataCommon) MainPRepCount() int {
 	return term.mainPRepCount
 }
 
-func (term *termData) GetElectedPRepCount() int {
+func (term *termDataCommon) GetElectedPRepCount() int {
 	return len(term.prepSnapshots)
 }
 
-func (term *termData) RewardFund() *RewardFund {
+func (term *termDataCommon) RewardFund() *RewardFund {
 	return term.rewardFund
 }
 
-func (term *termData) Iglobal() *big.Int {
-	return term.RewardFund().IGlobal()
-}
-
-func (term *termData) Iprep() icmodule.Rate {
-	return term.RewardFund().IPrep()
-}
-
-func (term *termData) Icps() icmodule.Rate {
-	return term.RewardFund().ICps()
-}
-
-func (term *termData) Irelay() icmodule.Rate {
-	return term.RewardFund().IRelay()
-}
-
-func (term *termData) Ivoter() icmodule.Rate {
-	return term.RewardFund().IVoter()
-}
-
-func (term *termData) BondRequirement() icmodule.Rate {
+func (term *termDataCommon) BondRequirement() icmodule.Rate {
 	return term.bondRequirement
 }
 
-func (term *termData) Revision() int {
+func (term *termDataCommon) Revision() int {
 	return term.revision
 }
 
-func (term *termData) MinimumBond() *big.Int {
-	return term.minimumBond
-}
-
-func (term *termData) GetEndHeight() int64 {
+func (term *termDataCommon) GetEndHeight() int64 {
 	if term == nil {
 		return -1
 	}
 	return term.startHeight + term.period - 1
 }
 
-func (term *termData) GetIISSVersion() int {
+func (term *termDataCommon) GetIISSVersion() int {
 	if term.revision >= icmodule.RevisionIISS4R1 {
 		return IISSVersion4
 	} else if term.revision >= icmodule.RevisionEnableIISS3 {
@@ -215,7 +180,7 @@ func (term *termData) GetIISSVersion() int {
 	return IISSVersion2
 }
 
-func (term *termData) GetVoteStartHeight() int64 {
+func (term *termDataCommon) GetVoteStartHeight() int64 {
 	if term.sequence == 0 {
 		// If either of initial validators are not registered as PReps
 		// when it's decentralized, system will fail
@@ -224,36 +189,33 @@ func (term *termData) GetVoteStartHeight() int64 {
 	return -1
 }
 
-func (term *termData) GetPRepSnapshotCount() int {
+func (term *termDataCommon) GetPRepSnapshotCount() int {
 	return len(term.prepSnapshots)
 }
 
-func (term *termData) GetPRepSnapshotByIndex(index int) *PRepSnapshot {
+func (term *termDataCommon) GetPRepSnapshotByIndex(index int) *PRepSnapshot {
 	return term.prepSnapshots[index]
 }
 
-func (term *termData) TotalSupply() *big.Int {
+func (term *termDataCommon) TotalSupply() *big.Int {
 	return term.totalSupply
 }
 
-func (term *termData) IsDecentralized() bool {
+func (term *termDataCommon) IsDecentralized() bool {
 	return term.isDecentralized
 }
 
-func (term *termData) equal(other *termData) bool {
+func (term *termDataCommon) equal(other *termDataCommon) bool {
 	if term == other {
 		return true
 	}
 	if term == nil || other == nil {
 		return false
 	}
-
 	return term.version == other.version &&
 		term.sequence == other.sequence &&
 		term.startHeight == other.startHeight &&
 		term.period == other.period &&
-		term.irep.Cmp(other.irep) == 0 &&
-		term.rrep.Cmp(other.rrep) == 0 &&
 		term.totalSupply.Cmp(other.totalSupply) == 0 &&
 		term.totalDelegated.Cmp(other.totalDelegated) == 0 &&
 		term.bondRequirement == other.bondRequirement &&
@@ -261,18 +223,15 @@ func (term *termData) equal(other *termData) bool {
 		term.isDecentralized == other.isDecentralized &&
 		term.mainPRepCount == other.mainPRepCount &&
 		term.rewardFund.Equal(other.rewardFund) &&
-		term.minimumBond.Cmp(other.minimumBond) == 0 &&
 		term.prepSnapshots.Equal(other.prepSnapshots)
 }
 
-func (term *termData) clone() termData {
-	return termData{
+func (term *termDataCommon) clone() termDataCommon {
+	return termDataCommon{
 		version:         term.version,
 		sequence:        term.sequence,
 		startHeight:     term.startHeight,
 		period:          term.period,
-		irep:            term.irep,
-		rrep:            term.rrep,
 		totalSupply:     term.totalSupply,
 		totalDelegated:  term.totalDelegated,
 		rewardFund:      term.rewardFund,
@@ -281,12 +240,11 @@ func (term *termData) clone() termData {
 		isDecentralized: term.isDecentralized,
 		mainPRepCount:   term.mainPRepCount,
 		prepSnapshots:   term.prepSnapshots.Clone(),
-		minimumBond:     term.minimumBond,
 	}
 }
 
-func (term *termData) ToJSON(sc icmodule.StateContext, state *State) map[string]interface{} {
-	jso := map[string]interface{}{
+func (term *termDataCommon) ToJSON(sc icmodule.StateContext, state *State) map[string]interface{} {
+	return map[string]interface{}{
 		"sequence":         term.sequence,
 		"startBlockHeight": term.startHeight,
 		"endBlockHeight":   term.GetEndHeight(),
@@ -302,17 +260,9 @@ func (term *termData) ToJSON(sc icmodule.StateContext, state *State) map[string]
 		"iissVersion":      term.GetIISSVersion(),
 		"preps":            term.prepsToJSON(sc, state),
 	}
-	switch term.version {
-	case termVersion1:
-		jso["irep"] = term.irep
-		jso["rrep"] = term.rrep
-	case termVersion2:
-		jso["minimumBond"] = term.minimumBond
-	}
-	return jso
 }
 
-func (term *termData) prepsToJSON(sc icmodule.StateContext, state *State) []interface{} {
+func (term *termDataCommon) prepsToJSON(sc icmodule.StateContext, state *State) []interface{} {
 	jso := make([]interface{}, 0, len(term.prepSnapshots))
 	for _, pss := range term.prepSnapshots {
 		prep := state.GetPRepByOwner(pss.Owner())
@@ -328,7 +278,7 @@ func (term *termData) prepsToJSON(sc icmodule.StateContext, state *State) []inte
 	return jso
 }
 
-func (term *termData) getTotalPower() *big.Int {
+func (term *termDataCommon) getTotalPower() *big.Int {
 	totalPower := new(big.Int)
 	for _, snapshot := range term.prepSnapshots {
 		totalPower.Add(totalPower, snapshot.Power())
@@ -336,9 +286,9 @@ func (term *termData) getTotalPower() *big.Int {
 	return totalPower
 }
 
-func (term *termData) String() string {
+func (term *termDataCommon) String() string {
 	return fmt.Sprintf(
-		"Term{ver:%d seq:%d start:%d end:%d period:%d ts:%s td:%s pss:%d irep:%s rrep:%s rf:%s revision:%d isDecentralized:%t mb:%d}",
+		"ver=%d seq=%d start=%d end=%d period=%d ts=%s td=%s pss=%d rf=%s rev=%d isDec=%t",
 		term.version,
 		term.sequence,
 		term.startHeight,
@@ -347,13 +297,155 @@ func (term *termData) String() string {
 		term.totalSupply,
 		term.totalDelegated,
 		len(term.prepSnapshots),
-		term.irep,
-		term.rrep,
 		term.rewardFund,
 		term.revision,
 		term.isDecentralized,
-		term.minimumBond,
 	)
+}
+
+// ========================================================
+
+type termDataExtV1 struct {
+	irep *big.Int
+	rrep *big.Int
+}
+
+func (tde *termDataExtV1) Irep() *big.Int {
+	if tde == nil {
+		return icmodule.BigIntZero
+	}
+	return tde.irep
+}
+
+func (tde *termDataExtV1) Rrep() *big.Int {
+	if tde == nil {
+		return icmodule.BigIntZero
+	}
+	return tde.rrep
+}
+
+func (tde *termDataExtV1) equal(other *termDataExtV1) bool {
+	if tde == other {
+		return true
+	}
+	if tde == nil || other == nil {
+		return false
+	}
+	return tde.irep.Cmp(other.irep) == 0 && tde.rrep.Cmp(other.rrep) == 0
+}
+
+func (tde *termDataExtV1) String() string {
+	return fmt.Sprintf("irep=%d rrep=%d", tde.Irep(), tde.Rrep())
+}
+
+func (tde *termDataExtV1) clone() *termDataExtV1 {
+	if tde == nil {
+		return nil
+	}
+	return newTermDataExtV1(tde.irep, tde.rrep)
+}
+
+func newTermDataExtV1(irep, rrep *big.Int) *termDataExtV1 {
+	return &termDataExtV1{irep, rrep}
+}
+
+// ========================================================
+
+type termDataExtV2 struct {
+	minimumBond *big.Int
+}
+
+func (tde *termDataExtV2) MinimumBond() *big.Int {
+	if tde == nil {
+		return icmodule.BigIntZero
+	}
+	return tde.minimumBond
+}
+
+func (tde *termDataExtV2) equal(other *termDataExtV2) bool {
+	if tde == other {
+		return true
+	}
+	if tde == nil || other == nil {
+		return false
+	}
+	return tde.minimumBond.Cmp(other.minimumBond) == 0
+}
+
+func (tde *termDataExtV2) String() string {
+	return fmt.Sprintf("minBond=%d", tde.MinimumBond())
+}
+
+func (tde *termDataExtV2) clone() *termDataExtV2 {
+	if tde == nil {
+		return nil
+	}
+	return &termDataExtV2{tde.minimumBond}
+}
+
+func newTermDataExtV2(minimumBond *big.Int) *termDataExtV2 {
+	return &termDataExtV2{minimumBond}
+}
+
+// ========================================================
+
+type termData struct {
+	termDataCommon
+	*termDataExtV1
+	*termDataExtV2
+}
+
+func (term *termData) equal(other *termData) bool {
+	if !term.termDataCommon.equal(&other.termDataCommon) {
+		return false
+	}
+	switch term.Version() {
+	case termVersion1:
+		return term.termDataExtV1.equal(other.termDataExtV1)
+	case termVersion2:
+		return term.termDataExtV2.equal(other.termDataExtV2)
+	}
+	return true
+}
+
+func (term *termData) clone() termData {
+	td := termData{
+		termDataCommon:	term.termDataCommon.clone(),
+	}
+	switch term.Version() {
+	case termVersion1:
+		td.termDataExtV1 = term.termDataExtV1.clone()
+	case termVersion2:
+		td.termDataExtV2 = term.termDataExtV2.clone()
+	}
+	return td
+}
+
+func (term *termData) ToJSON(sc icmodule.StateContext, state *State) map[string]interface{} {
+	jso := term.termDataCommon.ToJSON(sc, state)
+	switch term.Version() {
+	case termVersion1:
+		jso["irep"] = term.Irep()
+		jso["rrep"] = term.Rrep()
+	case termVersion2:
+		jso["minimumBond"] = term.MinimumBond()
+	}
+	return jso
+}
+
+func (term *termData) String() string {
+	sb := strings.Builder{}
+	sb.WriteString("Term{")
+	sb.WriteString(term.termDataCommon.String())
+	sb.WriteByte(' ')
+	switch term.Version() {
+	case termVersion1:
+		sb.WriteString(term.termDataExtV1.String())
+	case termVersion2:
+		sb.WriteString(term.termDataExtV2.String())
+	}
+	sb.WriteString("}")
+	return sb.String()
 }
 
 func (term *termData) Format(f fmt.State, c rune) {
@@ -361,8 +453,8 @@ func (term *termData) Format(f fmt.State, c rune) {
 	case 'v':
 		var format string
 		if f.Flag('+') {
-			format = "Term{ver:%d seq:%d start:%d end:%d period:%d totalSupply:%s totalDelegated:%s " +
-				"prepSnapshots:%d irep:%s rrep:%s rf:%+v revision:%d isDecentralized:%t minimumBond:%d}"
+			format = "Term{ver=%d seq=%d start=%d end=%d period=%d totalSupply=%s totalDelegated=%s " +
+				"prepSnapshots=%d irep=%s rrep=%s rf=%+v revision=%d isDecentralized=%t minimumBond=%d}"
 		} else {
 			format = "Term{%d %d %d %d %d %s %s %d %s %s %v %d %t %d}"
 		}
@@ -377,12 +469,12 @@ func (term *termData) Format(f fmt.State, c rune) {
 			term.totalSupply,
 			term.totalDelegated,
 			len(term.prepSnapshots),
-			term.irep,
-			term.rrep,
+			term.Irep(),
+			term.Rrep(),
 			term.rewardFund,
 			term.revision,
 			term.isDecentralized,
-			term.minimumBond,
+			term.MinimumBond(),
 		)
 	case 's':
 		_, _ = fmt.Fprint(f, term.String())
@@ -441,7 +533,7 @@ func (term *TermSnapshot) RLPDecodeFields(decoder codec.Decoder) error {
 }
 
 func (term *TermSnapshot) RLPEncodeFields(encoder codec.Encoder) error {
-	switch term.version {
+	switch term.Version() {
 	case termVersion1:
 		return encoder.EncodeMulti(
 			term.sequence,
@@ -489,16 +581,20 @@ func (term *TermSnapshot) Equal(o icobject.Impl) bool {
 	return term.equal(&other.termData)
 }
 
-func (term *TermSnapshot) GetPRepSnapshotCount() int {
-	return len(term.prepSnapshots)
-}
-
 func NewTermWithTag(tag icobject.Tag) *TermSnapshot {
-	return &TermSnapshot{
+	version := tag.Version()
+	tss := &TermSnapshot{
 		termData: termData{
-			version: tag.Version(),
+			termDataCommon: termDataCommon{version: version},
 		},
 	}
+	switch version {
+	case termVersion1:
+		tss.termDataExtV1 = newTermDataExtV1(icmodule.BigIntZero, icmodule.BigIntZero)
+	case termVersion2:
+		tss.termDataExtV2 = newTermDataExtV2(icmodule.BigIntZero)
+	}
+	return tss
 }
 
 // ==================================================================
@@ -534,16 +630,20 @@ func (term *TermState) SetMainPRepCount(mainPRepCount int) {
 }
 
 func (term *TermState) SetIrep(irep *big.Int) {
-	term.irep = irep
+	if term.termDataExtV1 != nil {
+		term.irep = irep
+	}
 }
 
 func (term *TermState) SetRrep(rrep *big.Int) {
-	term.rrep = rrep
+	if term.termDataExtV1 != nil {
+		term.rrep = rrep
+	}
 }
 
 func NewNextTerm(state *State, totalSupply *big.Int, revision int) *TermState {
-	ts := state.GetTermSnapshot()
-	if ts == nil {
+	tss := state.GetTermSnapshot()
+	if tss == nil {
 		return nil
 	}
 	var version int
@@ -553,40 +653,49 @@ func NewNextTerm(state *State, totalSupply *big.Int, revision int) *TermState {
 		version = termVersion2
 	}
 
-	return &TermState{
+	ts := &TermState{
 		termData: termData{
-			version:         version,
-			sequence:        ts.Sequence() + 1,
-			startHeight:     ts.GetEndHeight() + 1,
-			period:          state.GetTermPeriod(),
-			irep:            state.GetIRep(),
-			rrep:            state.GetRRep(),
-			totalSupply:     totalSupply,
-			totalDelegated:  state.GetTotalDelegation(),
-			rewardFund:      state.GetRewardFund(revision),
-			bondRequirement: state.GetBondRequirement(),
-			revision:        revision,
-			prepSnapshots:   ts.prepSnapshots.Clone(),
-			isDecentralized: ts.IsDecentralized(),
-			minimumBond:     state.GetMinimumBond(),
+			termDataCommon: termDataCommon{
+				version:         version,
+				sequence:        tss.Sequence() + 1,
+				startHeight:     tss.GetEndHeight() + 1,
+				period:          state.GetTermPeriod(),
+				totalSupply:     totalSupply,
+				totalDelegated:  state.GetTotalDelegation(),
+				rewardFund:      state.GetRewardFund(revision),
+				bondRequirement: state.GetBondRequirement(),
+				revision:        revision,
+				prepSnapshots:   tss.prepSnapshots.Clone(),
+				isDecentralized: tss.IsDecentralized(),
+			},
 		},
 	}
+	switch version {
+	case termVersion1:
+		ts.termDataExtV1 = newTermDataExtV1(state.GetIRep(), state.GetRRep())
+	case termVersion2:
+		ts.termDataExtV2 = newTermDataExtV2(state.GetMinimumBond())
+	}
+
+	return ts
 }
 
 func GenesisTerm(state *State, startHeight int64, revision int) *TermState {
 	return &TermState{
 		termData: termData{
-			sequence:        0,
-			startHeight:     startHeight,
-			period:          state.GetTermPeriod(),
-			irep:            state.GetIRep(),
-			rrep:            state.GetRRep(),
-			totalSupply:     icmodule.BigIntZero,
-			totalDelegated:  icmodule.BigIntZero,
-			rewardFund:      state.GetRewardFundV1().Clone(),
-			bondRequirement: state.GetBondRequirement(),
-			revision:        revision,
-			isDecentralized: false,
+			termDataCommon: termDataCommon{
+				version:         termVersion1,
+				sequence:        0,
+				startHeight:     startHeight,
+				period:          state.GetTermPeriod(),
+				totalSupply:     icmodule.BigIntZero,
+				totalDelegated:  icmodule.BigIntZero,
+				rewardFund:      state.GetRewardFundV1().Clone(),
+				bondRequirement: state.GetBondRequirement(),
+				revision:        revision,
+				isDecentralized: false,
+			},
+			termDataExtV1: newTermDataExtV1(state.GetIRep(), state.GetRRep()),
 		},
 	}
 }

--- a/icon/iiss/icstate/term.go
+++ b/icon/iiss/icstate/term.go
@@ -54,7 +54,7 @@ func (pss *PRepSnapshot) RLPDecodeSelf(d codec.Decoder) error {
 }
 
 func (pss *PRepSnapshot) String() string {
-	return fmt.Sprintf("PRepSnapshot{owner=%s power=%d}", pss.owner, pss.Power())
+	return fmt.Sprintf("PRepSnapshot{%s %d}", pss.owner, pss.Power())
 }
 
 func NewPRepSnapshot(owner module.Address, power *big.Int) *PRepSnapshot {

--- a/icon/iiss/icstate/term.go
+++ b/icon/iiss/icstate/term.go
@@ -194,14 +194,6 @@ func (term *termDataCommon) GetVoteStartHeight() int64 {
 	return -1
 }
 
-func (term *termDataCommon) GetPRepSnapshotCount() int {
-	return len(term.prepSnapshots)
-}
-
-func (term *termDataCommon) GetPRepSnapshotByIndex(index int) *PRepSnapshot {
-	return term.prepSnapshots[index]
-}
-
 func (term *termDataCommon) PRepSnapshots() PRepSnapshots {
 	return term.prepSnapshots
 }

--- a/icon/iiss/icstate/term.go
+++ b/icon/iiss/icstate/term.go
@@ -22,10 +22,6 @@ func (pss *PRepSnapshot) Owner() module.Address {
 	return pss.owner
 }
 
-func (pss *PRepSnapshot) BondedDelegation() *big.Int {
-	return pss.power
-}
-
 func (pss *PRepSnapshot) Power() *big.Int {
 	return pss.power
 }
@@ -39,13 +35,6 @@ func (pss *PRepSnapshot) Equal(other *PRepSnapshot) bool {
 	}
 	return pss.owner.Equal(other.owner) &&
 		pss.power.Cmp(other.power) == 0
-}
-
-func (pss *PRepSnapshot) Clone() *PRepSnapshot {
-	return &PRepSnapshot{
-		owner: pss.owner,
-		power: pss.power,
-	}
 }
 
 func (pss *PRepSnapshot) ToJSON() map[string]interface{} {
@@ -65,7 +54,7 @@ func (pss *PRepSnapshot) RLPDecodeSelf(d codec.Decoder) error {
 }
 
 func (pss *PRepSnapshot) String() string {
-	return fmt.Sprintf("[%s, %v]", pss.owner, pss.Power())
+	return fmt.Sprintf("PRepSnapshot{owner=%s power=%d}", pss.owner, pss.Power())
 }
 
 func NewPRepSnapshot(owner module.Address, power *big.Int) *PRepSnapshot {
@@ -249,10 +238,6 @@ func (term *termData) TotalSupply() *big.Int {
 
 func (term *termData) IsDecentralized() bool {
 	return term.isDecentralized
-}
-
-func (term *termData) IsFirstBlockOnDecentralized(blockHeight int64) bool {
-	return term.isDecentralized && term.sequence == 0 && term.startHeight == blockHeight
 }
 
 func (term *termData) equal(other *termData) bool {
@@ -489,7 +474,7 @@ func (term *TermSnapshot) RLPEncodeFields(encoder codec.Encoder) error {
 			term.minimumBond,
 		)
 	default:
-		return errors.IllegalArgumentError.Errorf("illegal Term version %d", term.version)
+		return errors.IllegalArgumentError.Errorf("IllegalTermVersion(%d)", term.version)
 	}
 }
 
@@ -596,8 +581,8 @@ func GenesisTerm(state *State, startHeight int64, revision int) *TermState {
 			period:          state.GetTermPeriod(),
 			irep:            state.GetIRep(),
 			rrep:            state.GetRRep(),
-			totalSupply:     new(big.Int),
-			totalDelegated:  new(big.Int),
+			totalSupply:     icmodule.BigIntZero,
+			totalDelegated:  icmodule.BigIntZero,
 			rewardFund:      state.GetRewardFundV1().Clone(),
 			bondRequirement: state.GetBondRequirement(),
 			revision:        revision,

--- a/icon/iiss/icstate/term.go
+++ b/icon/iiss/icstate/term.go
@@ -491,7 +491,7 @@ type TermSnapshot struct {
 
 func (term *TermSnapshot) RLPDecodeFields(decoder codec.Decoder) error {
 	var bondRequirement int64
-	switch term.version {
+	switch term.Version() {
 	case termVersion1:
 		if err := decoder.DecodeAll(
 			&term.sequence,
@@ -567,7 +567,7 @@ func (term *TermSnapshot) RLPEncodeFields(encoder codec.Encoder) error {
 			term.minimumBond,
 		)
 	default:
-		return errors.IllegalArgumentError.Errorf("IllegalTermVersion(%d)", term.version)
+		return errors.IllegalArgumentError.Errorf("IllegalTermVersion(%d)", term.Version())
 	}
 }
 

--- a/icon/iiss/icstate/term_test.go
+++ b/icon/iiss/icstate/term_test.go
@@ -96,7 +96,7 @@ func TestPRepSnapshot_Equal(t *testing.T) {
 	}{
 		{nil, nil, true},
 		{p0, p0, true},
-		{p0, p0.Clone(), true},
+		{p0, NewPRepSnapshot(p0.Owner(), p0.Power()), true},
 		{p0, newPRepSnapshot(owner0, delegated, bond), true},
 		{nil, p0, false},
 		{p0, nil, false},
@@ -268,7 +268,7 @@ func TestTerm_TotalBondedDelegation(t *testing.T) {
 
 	totalPower := new(big.Int)
 	for _, snapshot := range prepSnapshots {
-		totalPower.Add(totalPower, snapshot.BondedDelegation())
+		totalPower.Add(totalPower, snapshot.Power())
 	}
 	assert.Zero(t, totalPower.Cmp(term.getTotalPower()))
 

--- a/icon/iiss/icstate/term_test.go
+++ b/icon/iiss/icstate/term_test.go
@@ -316,7 +316,7 @@ func TestTerm_TotalBondedDelegation(t *testing.T) {
 	size := 100
 	term := newTermState(termVersion1, 0, 43120)
 	prepSnapshots := newDummyPRepSnapshots(size)
-	term.SetPRepSnapshots(prepSnapshots.Clone())
+	term.prepSnapshots = prepSnapshots.Clone()
 	assert.Equal(t, term.GetElectedPRepCount(), len(prepSnapshots))
 
 	totalPower := new(big.Int)

--- a/icon/iiss/icstate/term_test.go
+++ b/icon/iiss/icstate/term_test.go
@@ -324,11 +324,7 @@ func TestTerm_TotalBondedDelegation(t *testing.T) {
 		totalPower.Add(totalPower, snapshot.Power())
 	}
 	assert.Zero(t, totalPower.Cmp(term.getTotalPower()))
-
-	for i := 0; i < size; i++ {
-		ps := term.GetPRepSnapshotByIndex(i)
-		assert.Equal(t, ps, prepSnapshots[i])
-	}
+	assert.True(t, term.PRepSnapshots().Equal(prepSnapshots))
 }
 
 func TestTermSnapshot_RLPDecodeFields(t *testing.T) {
@@ -480,9 +476,9 @@ func TestGenesisTerm(t *testing.T) {
 	assert.Equal(t, tp, termState.Period())
 	assert.Equal(t, br, termState.BondRequirement())
 	assert.False(t, termState.IsDecentralized())
-	assert.Zero(t, termState.GetPRepSnapshotCount())
 	assert.Equal(t, IISSVersion2, termState.GetIISSVersion())
 	assert.Equal(t, start+1, termState.GetVoteStartHeight())
 	assert.True(t, termState.RewardFund().Equal(rf))
 	assert.Zero(t, termState.MainPRepCount())
+	assert.Zero(t, termState.GetElectedPRepCount())
 }

--- a/icon/iiss/icstate/term_test.go
+++ b/icon/iiss/icstate/term_test.go
@@ -78,10 +78,10 @@ func newTermState(version, sequence int, period int64) *TermState {
 	ts := &TermState{
 		termData: termData{
 			termDataCommon: termDataCommon{
-				version:     version,
-				sequence:    sequence,
-				period:      period,
-				rewardFund:  rf,
+				version:    version,
+				sequence:   sequence,
+				period:     period,
+				rewardFund: rf,
 			},
 		},
 	}
@@ -153,7 +153,7 @@ func TestPRepSnapshot_String(t *testing.T) {
 	owner := newDummyAddress(1)
 	power := big.NewInt(1000)
 	pss := NewPRepSnapshot(owner, power)
-	exp := fmt.Sprintf("PRepSnapshot{owner=%s power=%d}", owner, power)
+	exp := fmt.Sprintf("PRepSnapshot{%s %d}", owner, power)
 	assert.Equal(t, exp, pss.String())
 }
 
@@ -166,8 +166,8 @@ func TestPRepSnapshots_Equal(t *testing.T) {
 	br := icmodule.ToRate(5)
 	cfg := NewPRepCountConfig(22, 78, 3)
 	sc := newMockStateContext(map[string]interface{}{
-		"bh": int64(1000),
-		"rev": icmodule.RevisionBTP2-1,
+		"bh":  int64(1000),
+		"rev": icmodule.RevisionBTP2 - 1,
 	})
 
 	preps := newDummyPReps(size)
@@ -272,6 +272,153 @@ func TestPRepSnapshots_String(t *testing.T) {
 	}
 	exp := fmt.Sprintf("PRepSnapshots{%s, %s}", p[0], p[1])
 	assert.Equal(t, exp, p.String())
+}
+
+// =============================================================================
+// termDataExtV1
+// =============================================================================
+
+func TestTermDataExtV1_String(t *testing.T) {
+	args := []struct {
+		isNil bool
+		irep  int64
+		rrep  int64
+		exp   string
+	}{
+		{true, 10, 20, "irep=0 rrep=0"},
+		{false, 0, 0, "irep=0 rrep=0"},
+		{false, 100, 200, "irep=100 rrep=200"},
+	}
+
+	for i, arg := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			var tde *termDataExtV1
+			irep := arg.irep
+			rrep := arg.rrep
+
+			if !arg.isNil {
+				tde = newTermDataExtV1(big.NewInt(irep), big.NewInt(rrep))
+			}
+			assert.Equal(t, arg.exp, tde.String())
+		})
+	}
+}
+
+func TestTermDataExtV1_clone(t *testing.T) {
+	args := []*termDataExtV1{
+		nil,
+		newTermDataExtV1(big.NewInt(10), big.NewInt(20)),
+	}
+	for i, ext := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			clone := ext.clone()
+			assert.True(t, ext.equal(clone))
+			if ext == nil {
+				assert.Nil(t, clone)
+				assert.Zero(t, ext.Irep().Sign())
+				assert.Zero(t, ext.Rrep().Sign())
+			} else {
+				assert.Zero(t, ext.Irep().Cmp(clone.Irep()))
+				assert.Zero(t, ext.Rrep().Cmp(clone.Rrep()))
+			}
+		})
+	}
+}
+
+func TestTermDataExt1_equal(t *testing.T) {
+	v0 := big.NewInt(10)
+	v1 := big.NewInt(20)
+	args := []struct {
+		ext0, ext1 *termDataExtV1
+		isEqual    bool
+	}{
+		{nil, nil, true},
+		{newTermDataExtV1(v0, v1), nil, false},
+		{nil, newTermDataExtV1(v0, v1), false},
+		{newTermDataExtV1(v0, v1), newTermDataExtV1(v1, v0), false},
+		{newTermDataExtV1(v0, v1), newTermDataExtV1(v0, v1), true},
+	}
+	for i, arg := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			ext0 := arg.ext0
+			ext1 := arg.ext1
+			assert.Equal(t, arg.isEqual, ext0.equal(ext1))
+			assert.Equal(t, arg.isEqual, ext1.equal(ext0))
+		})
+	}
+}
+
+// =============================================================================
+// termDataExtV2
+// =============================================================================
+
+func TestTermDataExtV2_String(t *testing.T) {
+	args := []struct {
+		isNil   bool
+		minBond int64
+		exp     string
+	}{
+		{true, 100, "minBond=0"},
+		{false, 0, "minBond=0"},
+		{false, 100, "minBond=100"},
+	}
+
+	for i, arg := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			var tde *termDataExtV2
+			if !arg.isNil {
+				tde = newTermDataExtV2(big.NewInt(arg.minBond))
+			}
+			assert.Equal(t, arg.exp, tde.String())
+		})
+	}
+}
+
+func TestTermDataExtV2_clone(t *testing.T) {
+	args := []*termDataExtV2{
+		nil,
+		newTermDataExtV2(big.NewInt(1)),
+	}
+	for i, ext := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			clone := ext.clone()
+			assert.True(t, ext.equal(clone))
+			if ext == nil {
+				assert.Nil(t, clone)
+				assert.Zero(t, ext.MinimumBond().Sign())
+			} else {
+				assert.Zero(t, ext.MinimumBond().Cmp(clone.MinimumBond()))
+			}
+		})
+	}
+}
+
+func TestTermDataExt2_equal(t *testing.T) {
+	args := []struct {
+		ext0, ext1 *termDataExtV2
+		isEqual    bool
+	}{
+		{nil, nil, true},
+		{newTermDataExtV2(big.NewInt(1)), nil, false},
+		{nil, newTermDataExtV2(big.NewInt(1)), false},
+		{newTermDataExtV2(big.NewInt(1)), newTermDataExtV2(big.NewInt(2)), false},
+		{newTermDataExtV2(big.NewInt(2)), newTermDataExtV2(big.NewInt(1)), false},
+		{newTermDataExtV2(big.NewInt(1)), newTermDataExtV2(big.NewInt(1)), true},
+	}
+	for i, arg := range args {
+		name := fmt.Sprintf("case-%02d", i)
+		t.Run(name, func(t *testing.T) {
+			ext0 := arg.ext0
+			ext1 := arg.ext1
+			assert.Equal(t, arg.isEqual, ext0.equal(ext1))
+			assert.Equal(t, arg.isEqual, ext1.equal(ext0))
+		})
+	}
 }
 
 // =============================================================================
@@ -481,4 +628,126 @@ func TestGenesisTerm(t *testing.T) {
 	assert.True(t, termState.RewardFund().Equal(rf))
 	assert.Zero(t, termState.MainPRepCount())
 	assert.Zero(t, termState.GetElectedPRepCount())
+	assert.Zero(t, termState.TotalSupply().Sign())
+}
+
+func TestNewNextTerm(t *testing.T) {
+	var err error
+	start := int64(1000)
+	tp := int64(icmodule.DefaultTermPeriod)
+	br := icmodule.ToRate(5)
+	irep := big.NewInt(1000)
+	rrep := big.NewInt(2000)
+	totalSupply := big.NewInt(1_000_000_000)
+	cfg := NewPRepCountConfig(22, 78, 0)
+
+	rf, err := NewSafeRewardFundV1(
+		big.NewInt(3_000_000),
+		icmodule.ToRate(13),
+		icmodule.ToRate(10),
+		icmodule.ToRate(0),
+		icmodule.ToRate(77),
+	)
+	assert.NoError(t, err)
+
+	// Initialize State
+	state := newDummyState(false)
+	assert.NoError(t, state.SetTermPeriod(tp))
+	assert.NoError(t, state.SetBondRequirement(br))
+	assert.NoError(t, state.SetIRep(irep))
+	assert.NoError(t, state.SetRRep(rrep))
+	assert.NoError(t, state.SetRewardFund(rf))
+
+	termState0 := GenesisTerm(state, start, icmodule.RevisionIISS)
+	assert.NoError(t, state.SetTermSnapshot(termState0.GetSnapshot()))
+
+	// Initialize PRepSet
+	sc := newMockStateContext(map[string]interface{}{
+		"rev": icmodule.RevisionDecentralize,
+		"bh":  termState0.GetEndHeight(),
+	})
+
+	activePReps := newDummyPReps(90)
+	prepSet := NewPRepSet(sc, activePReps, cfg)
+
+	// -------------------------------------------------------------
+	// Centralized -> Decentralized
+	// -------------------------------------------------------------
+	start = termState0.StartHeight() + tp
+	expElectedPRepCount := icutils.Min(cfg.ElectedPReps(), len(activePReps))
+	termState1 := NewNextTerm(sc, state, totalSupply, prepSet)
+	assert.NotNil(t, termState1)
+	assert.Zero(t, termState1.Sequence())
+	assert.Equal(t, start, termState1.StartHeight())
+	assert.Equal(t, start+tp-1, termState1.GetEndHeight())
+	assert.Zero(t, irep.Cmp(termState1.Irep()))
+	assert.Zero(t, rrep.Cmp(termState1.Rrep()))
+	assert.Zero(t, termState1.MinimumBond().Sign())
+	assert.Equal(t, termVersion1, termState1.Version())
+	assert.Equal(t, sc.RevisionValue(), termState1.Revision())
+	assert.Equal(t, tp, termState1.Period())
+	assert.Equal(t, br, termState1.BondRequirement())
+	assert.True(t, termState1.IsDecentralized())
+	assert.Equal(t, IISSVersion2, termState1.GetIISSVersion())
+	assert.Equal(t, start+1, termState1.GetVoteStartHeight())
+	assert.True(t, termState1.RewardFund().Equal(rf))
+	assert.Equal(t, cfg.MainPReps(), termState1.MainPRepCount())
+	assert.Equal(t, expElectedPRepCount, termState1.GetElectedPRepCount())
+	assert.Equal(t, expElectedPRepCount, len(termState1.PRepSnapshots()))
+	assert.Zero(t, totalSupply.Cmp(termState1.TotalSupply()))
+	assert.NoError(t, state.SetTermSnapshot(termState1.GetSnapshot()))
+
+	irep = big.NewInt(1234)
+	termState1.SetIrep(irep)
+	assert.Zero(t, irep.Cmp(termState1.Irep()))
+	irep = big.NewInt(5678)
+	termState1.SetRrep(rrep)
+	assert.Zero(t, rrep.Cmp(termState1.Rrep()))
+
+	// -------------------------------------------------------------
+	// Revision: IISS -> IISS4R1
+	// -------------------------------------------------------------
+	minBond := big.NewInt(10_000)
+	assert.NoError(t, state.SetMinimumBond(minBond))
+
+	sc = newMockStateContext(map[string]interface{}{
+		"rev": icmodule.RevisionIISS4R1,
+		"bh":  termState1.GetEndHeight(),
+	})
+	start = termState1.StartHeight() + tp
+	r := state.GetRewardFundV1()
+	assert.NoError(t, state.SetRewardFund(r.ToRewardFundV2())) // onRevIISS4R0
+
+	termState2 := NewNextTerm(sc, state, totalSupply, prepSet)
+	assert.NotNil(t, termState2)
+	assert.Equal(t, termState1.Sequence()+1, termState2.Sequence())
+	assert.Equal(t, start, termState2.StartHeight())
+	assert.Equal(t, start+tp-1, termState2.GetEndHeight())
+	assert.Zero(t, termState2.Irep().Sign())
+	assert.Zero(t, termState2.Rrep().Sign())
+	assert.Zero(t, minBond.Cmp(termState2.MinimumBond()))
+	assert.Equal(t, termVersion2, termState2.Version())
+	assert.Equal(t, sc.RevisionValue(), termState2.Revision())
+	assert.Equal(t, tp, termState2.Period())
+	assert.Equal(t, br, termState2.BondRequirement())
+	assert.True(t, termState2.IsDecentralized())
+	assert.Equal(t, IISSVersion4, termState2.GetIISSVersion())
+	assert.Equal(t, int64(-1), termState2.GetVoteStartHeight())
+	assert.True(t, state.GetRewardFundV2().Equal(termState2.RewardFund()))
+	assert.Equal(t, cfg.MainPReps(), termState2.MainPRepCount())
+	assert.Equal(t, expElectedPRepCount, termState2.GetElectedPRepCount())
+	assert.Equal(t, expElectedPRepCount, len(termState2.PRepSnapshots()))
+	assert.Zero(t, totalSupply.Cmp(termState2.TotalSupply()))
+	assert.NoError(t, state.SetTermSnapshot(termState2.GetSnapshot()))
+
+	termState2.SetIrep(big.NewInt(1234))
+	assert.Zero(t, termState2.Irep().Sign())
+	termState2.SetRrep(big.NewInt(1234))
+	assert.Zero(t, termState2.Rrep().Sign())
+
+	// termDataExtV1 == nil, termDataExtV2 != nil
+	jso := termState2.ToJSON(sc, state)
+	assert.Nil(t, jso["irep"])
+	assert.Nil(t, jso["rrep"])
+	assert.Zero(t, minBond.Cmp(jso["minimumBond"].(*big.Int)))
 }

--- a/icon/iiss/icstate/validators.go
+++ b/icon/iiss/icstate/validators.go
@@ -335,12 +335,9 @@ func NewValidatorsStateWithSnapshot(vss *ValidatorsSnapshot) *ValidatorsState {
 
 func NewValidatorsSnapshotWithPRepSnapshot(
 	prepSnapshots PRepSnapshots, ownerToNodeMapper OwnerToNodeMappable, size int) *ValidatorsSnapshot {
-	vd := validatorsData{}
-	vd.init(prepSnapshots, ownerToNodeMapper, size)
-
-	return &ValidatorsSnapshot{
-		validatorsData: vd,
-	}
+	vss := &ValidatorsSnapshot{}
+	vss.validatorsData.init(prepSnapshots, ownerToNodeMapper, size)
+	return vss
 }
 
 // changeValidatorNodeAddress is called when a main prep wants to change its node address

--- a/icon/iiss/issuer.go
+++ b/icon/iiss/issuer.go
@@ -276,9 +276,9 @@ func getIssueDataV1(
 func getIssueDataV2(issueInfo *icstate.Issue, term *icstate.TermSnapshot) *IssueResultJSON {
 	var reward, remains *big.Int
 	if term.Revision() < icmodule.RevisionFixIGlobal {
-		reward, remains = new(big.Int).DivMod(term.Iglobal(), big.NewInt(term.Period()), new(big.Int))
+		reward, remains = new(big.Int).DivMod(term.RewardFund().IGlobal(), big.NewInt(term.Period()), new(big.Int))
 	} else {
-		reward, remains = new(big.Int).DivMod(term.Iglobal(), big.NewInt(icmodule.MonthBlock), new(big.Int))
+		reward, remains = new(big.Int).DivMod(term.RewardFund().IGlobal(), big.NewInt(icmodule.MonthBlock), new(big.Int))
 	}
 	if remains.Sign() == 1 {
 		reward.Add(reward, intconv.BigIntOne)


### PR DESCRIPTION
* Introduce termDataCommon, termDataExtV1, termDataExtV2 structs in TermSnapshot and TermState
* Shrink ExtensionStateImpl.onTermEnd() where term creation code is called.
* Remove useless codes
* Add unit-tests