### PR TITLE
Move SetMinimumBond() logic from ChainScore to ExtensionState

### DIFF
--- a/icon/chainscore_iiss.go
+++ b/icon/chainscore_iiss.go
@@ -925,22 +925,7 @@ func (s *chainScore) Ex_setMinimumBond(nBond *big.Int) error {
 	if err != nil {
 		return err
 	}
-	if nBond.Sign() < 0 {
-		return scoreresult.InvalidParameterError.New("NegativeMinimumBond")
-	}
-	oBond := es.State.GetMinimumBond()
-	if oBond.Cmp(nBond) == 0 {
-		return nil
-	}
-	if err = es.State.SetMinimumBond(nBond); err != nil {
-		return scoreresult.InvalidParameterError.Wrapf(
-			err,
-			"Failed to set minimum bond: bond=%d",
-			nBond,
-		)
-	}
-	iiss.EmitMinimumBondSetEvent(s.newCallContext(s.cc), nBond)
-	return nil
+	return es.SetMinimumBond(s.newCallContext(s.cc), nBond)
 }
 
 func (s *chainScore) newCallContext(cc contract.CallContext) icmodule.CallContext {

--- a/icon/iiss/extension.go
+++ b/icon/iiss/extension.go
@@ -2030,3 +2030,22 @@ func (es *ExtensionStateImpl) GetPRepCountConfig() (map[string]interface{}, erro
 		icstate.PRepCountExtra.String(): es.State.GetExtraMainPRepCount(),
 	}, nil
 }
+
+func (es *ExtensionStateImpl) SetMinimumBond(cc icmodule.CallContext, nBond *big.Int) error {
+	if nBond.Sign() < 0 {
+		return scoreresult.InvalidParameterError.New("NegativeMinimumBond")
+	}
+	oBond := es.State.GetMinimumBond()
+	if oBond.Cmp(nBond) == 0 {
+		return nil
+	}
+	if err := es.State.SetMinimumBond(nBond); err != nil {
+		return scoreresult.InvalidParameterError.Wrapf(
+			err,
+			"Failed to set minimum bond: bond=%d",
+			nBond,
+		)
+	}
+	EmitMinimumBondSetEvent(cc, nBond)
+	return nil
+}


### PR DESCRIPTION
This patch allows the simulator to more accurately test the SetMinimumBond() logic.