### PR TITLE
Fix #199

### DIFF
--- a/icon/iiss/calculator/iiss4.go
+++ b/icon/iiss/calculator/iiss4.go
@@ -50,12 +50,16 @@ func (r *iiss4Reward) Calculate() error {
 		return err
 	}
 
-	if err = r.processPrepReward(); err != nil {
-		return err
-	}
+	if r.g.GetElectedPRepCount() == 0 {
+		r.Logger().Debugf("there is no elected PRep. skip reward calculation")
+	} else {
+		if err = r.processPrepReward(); err != nil {
+			return err
+		}
 
-	if err = r.processVoterReward(); err != nil {
-		return err
+		if err = r.processVoterReward(); err != nil {
+			return err
+		}
 	}
 
 	if err = processBTP(r); err != nil {

--- a/icon/iiss/calculator/iiss4_test.go
+++ b/icon/iiss/calculator/iiss4_test.go
@@ -564,6 +564,18 @@ func TestReward(t *testing.T) {
 		}
 	})
 
+	// no elected PReps
+	org := r.pi.electedPRepCount
+	r.pi.electedPRepCount = 0
+	err = r.processPrepReward()
+	assert.NoError(t, err)
+	for _, p := range r.pi.rank {
+		assert.Equal(t, 0, p.commission.Sign())
+		assert.Equal(t, 0, p.voterReward.Sign())
+		assert.Equal(t, 0, p.wage.Sign())
+	}
+	r.pi.electedPRepCount = org
+
 	// processPrepReward()
 	err = r.processPrepReward()
 	assert.NoError(t, err)

--- a/icon/iiss/calculator/prep.go
+++ b/icon/iiss/calculator/prep.go
@@ -348,6 +348,10 @@ func fundToPeriodIScore(reward *big.Int, period int64) *big.Int {
 // CalculateReward calculates commission, wage and voter reward of the PRep.
 func (p *PRepInfo) CalculateReward(totalReward, totalMinWage, minBond *big.Int) error {
 	p.log.Debugf("CalculateReward()")
+	if p.electedPRepCount == 0 {
+		p.log.Debugf("skip PRepInfo.CalculateReward()")
+		return nil
+	}
 	tReward := fundToPeriodIScore(totalReward, p.GetTermPeriod())
 	minWage := fundToPeriodIScore(totalMinWage, p.GetTermPeriod())
 	p.log.Debugf("RewardFund: PRep: %d, wage: %d", tReward, minWage)

--- a/icon/iiss/calculator/prep_test.go
+++ b/icon/iiss/calculator/prep_test.go
@@ -417,3 +417,11 @@ func prepReward(prep *PRep, totalReward, totalPower int64, offsetLimit int) (rew
 	commission = prep.commissionRate.MulInt64(reward)
 	return
 }
+
+func TestPRepInfo_CalculateReward_without_elected_prep(t *testing.T) {
+	pInfo := newTestPRepInfo(nil, icmodule.ToRate(5), 100, 0)
+	assert.NotPanics(t, func() {
+		err := pInfo.CalculateReward(big.NewInt(1_000), big.NewInt(1_000), big.NewInt(300))
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
- skip reward calculation if there are no eletected PReps